### PR TITLE
infrastructure/hide-toolbar-in-intro-doc

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -13,6 +13,7 @@ export const parameters = {
     storySort: {
       order: ["Getting Started", "Library"],
     },
+    isToolshown: true,
   },
   docs: {
     theme: themes.dark,

--- a/src/stories/Introduction.stories.mdx
+++ b/src/stories/Introduction.stories.mdx
@@ -8,7 +8,7 @@ import Plugin from "./assets/plugin.svg";
 import Repo from "./assets/repo.svg";
 import StackAlt from "./assets/stackalt.svg";
 
-<Meta title="Getting Started/Introduction" />
+<Meta title="Getting Started/Introduction" parameters={{ options: { isToolshown: false } }} />
 
 <style>{`
   .subheading {


### PR DESCRIPTION
**Pull request recommendations:**
- [x] Name your pull request _your-development-type/short-description_. Ex: _feature/read-tiff-files_
- [ ] Link to any relevant issue in the PR description. Ex: _Resolves [gh-12], adds tiff file format support_
- [x] Provide context of changes.
- [ ] Provide relevant tests for your feature or bug fix.
- [ ] Provide or update documentation for any feature added by your pull request.

**Summary Of Changes**
PR includes a small Storybook configuration update. It hides the Storybook toolbar on the Introduction documentation page and also updates Storybook global config (`preview.js`) to ensure that the toolbar is still displayed in all the component stories. 

Minor Note (for the curious): I discovered if the `preview.js` config is not set then the changes made in the Introduction doc page propagate to all the stories resulting in the toolbar being hidden across all of Storybook. By globally setting `isToolBar: true` this issue is resolved.

This change has been made to (in theory) reduce the cognitive load for contributors accessing Storybook for the first time by reducing the number of UI elements to consider/think about.