### PR TITLE
bugfix/replace-require-with-import-from

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11881,6 +11881,27 @@
         "@types/react": "*"
       }
     },
+    "@types/react-router": {
+      "version": "5.1.13",
+      "resolved": "https://registry.npmjs.org/@types/react-router/-/react-router-5.1.13.tgz",
+      "integrity": "sha512-ZIuaO9Yrln54X6elg8q2Ivp6iK6p4syPsefEYAhRDAoqNh48C8VYUmB9RkXjKSQAJSJV0mbIFCX7I4vZDcHrjg==",
+      "dev": true,
+      "requires": {
+        "@types/history": "*",
+        "@types/react": "*"
+      }
+    },
+    "@types/react-router-dom": {
+      "version": "5.1.7",
+      "resolved": "https://registry.npmjs.org/@types/react-router-dom/-/react-router-dom-5.1.7.tgz",
+      "integrity": "sha512-D5mHD6TbdV/DNHYsnwBTv+y73ei+mMjrkGrla86HthE4/PVvL1J94Bu3qABU+COXzpL23T1EZapVVpwHuBXiUg==",
+      "dev": true,
+      "requires": {
+        "@types/history": "*",
+        "@types/react": "*",
+        "@types/react-router": "*"
+      }
+    },
     "@types/react-syntax-highlighter": {
       "version": "11.0.4",
       "resolved": "https://registry.npmjs.org/@types/react-syntax-highlighter/-/react-syntax-highlighter-11.0.4.tgz",

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "@types/jest": "^26.0.20",
     "@types/react": "^16.14.5",
     "@types/react-dom": "^16.9.5",
+    "@types/react-router-dom": "^5.1.7",
     "@typescript-eslint/eslint-plugin": "~2.8",
     "@typescript-eslint/parser": "~2.8",
     "babel-loader": "~8.0",

--- a/src/components/Tables/VotingTableRow/VotingTableRow.tsx
+++ b/src/components/Tables/VotingTableRow/VotingTableRow.tsx
@@ -3,7 +3,7 @@ import DecisionResult from "../../Shared/DecisionResult";
 import { MATTER_STATUS_DECISION } from "../../../constants/ProjectConstants";
 import { VOTE_DECISION } from "../../../constants/ProjectConstants";
 import { TAG_CONNECTOR } from "../../../constants/StyleConstants";
-const Link = require("react-router-dom").Link;
+import { Link } from "react-router-dom";
 import "@mozilla-protocol/core/protocol/css/protocol.css";
 
 type VotingTableRowProps = {


### PR DESCRIPTION
Fixes bug found from trying to launch the application.

We can't use `require` in client side JS, so just had to switch to `import {} from ""` syntax as well as install the types for the module.