### PR TITLE
bugfix/transcript-item-icon-svgs

### DIFF
--- a/src/components/Details/TranscriptItem/TranscriptItem.tsx
+++ b/src/components/Details/TranscriptItem/TranscriptItem.tsx
@@ -5,6 +5,8 @@ import { Popup } from "semantic-ui-react";
 import styled from "@emotion/styled";
 
 import DefaultAvatar from "../../Shared/DefaultAvatar";
+import DocumentTextIcon from "../../Shared/DocumentTextIcon";
+import PlayIcon from "../../Shared/PlayIcon";
 
 import { fontSizes } from "../../../styles/fonts";
 
@@ -56,16 +58,12 @@ const DefaultAvatarContainer = styled.div({
   height: AVATAR_SIZE,
 });
 
-interface ButtonProps {
-  label: string;
-}
-const Button = styled.button<ButtonProps>((props) => ({
-  fontSize: `${fontSizes.font_size_5} !important`,
-  padding: "1px 8px !important",
-  "&::before": {
-    content: `'${props.label}'`,
-  },
-}));
+const Button = styled.button({
+  padding: "2px 8px !important",
+  display: "flex",
+  justifyContent: "center",
+  alignItems: "center",
+});
 
 interface TranscriptItemProps {
   /**The speaker's name */
@@ -135,10 +133,11 @@ const TranscriptItem: FC<TranscriptItemProps> = ({
             trigger={
               <Button
                 aria-label="Jump to sentence in video"
-                label="⏵"
                 className="mzp-c-button mzp-t-neutral"
                 onClick={handleVideoClick}
-              />
+              >
+                <PlayIcon />
+              </Button>
             }
           />
         </div>
@@ -151,10 +150,11 @@ const TranscriptItem: FC<TranscriptItemProps> = ({
               trigger={
                 <Button
                   aria-label="Jump to sentence in transcript"
-                  label="→"
                   className="mzp-c-button mzp-t-neutral"
                   onClick={handleTranscriptClick}
-                />
+                >
+                  <DocumentTextIcon />
+                </Button>
               }
             />
           </div>

--- a/src/components/Shared/DocumentTextIcon.tsx
+++ b/src/components/Shared/DocumentTextIcon.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+
+const DocumentTextIcon = () => {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      className="h-6 w-6"
+      fill="none"
+      viewBox="0 0 24 24"
+      stroke="currentColor"
+      width="24"
+      height="24"
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={2}
+        d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
+      />
+    </svg>
+  );
+};
+
+export default DocumentTextIcon;

--- a/src/components/Shared/PlayIcon.tsx
+++ b/src/components/Shared/PlayIcon.tsx
@@ -1,0 +1,30 @@
+import React from "react";
+
+const PlayIcon = () => {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      className="h-6 w-6"
+      fill="none"
+      viewBox="0 0 24 24"
+      stroke="currentColor"
+      width="24"
+      height="24"
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={2}
+        d="M14.752 11.168l-3.197-2.132A1 1 0 0010 9.87v4.263a1 1 0 001.555.832l3.197-2.132a1 1 0 000-1.664z"
+      />
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={2}
+        d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+      />
+    </svg>
+  );
+};
+
+export default PlayIcon;


### PR DESCRIPTION
**Pull request recommendations:**
- [x] Name your pull request _your-development-type/short-description_. Ex: _feature/read-tiff-files_
- [ ] Link to any relevant issue in the PR description. Ex: _Resolves [gh-12], adds tiff file format support_
- [x] Provide context of changes.
TranscriptItem's play video clip and jump to sentence buttons uses Unicode chars that aren't consistent across devices.
Instead of using Unicode chars, use SVG icons from heroicons. This PR creates two SVG icons in shared dir and uses them in TranscriptItem.
- [ ] Provide relevant tests for your feature or bug fix.
- [x] Provide or update documentation for any feature added by your pull request. 
![image](https://user-images.githubusercontent.com/37560480/125734653-94225faf-82f6-4146-9c4d-5576e6d713b7.png)


Thanks for contributing!