### PR TITLE
bug/display error without causing another

### DIFF
--- a/src/containers/FetchDataContainer/FetchDataContainer.tsx
+++ b/src/containers/FetchDataContainer/FetchDataContainer.tsx
@@ -19,7 +19,7 @@ const FetchDataContainer: FC<FetchDataContainerProps> = ({
   if (error) {
     // Display the error for now.
     // TODO: throw the error and catch it with a general error boundary that displays the error page.
-    return <span>{error}</span>;
+    return <span>{error.toString()}</span>;
   }
   return <>{children}</>;
 };


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  ⚠️⚠️ Please do the following before submitting: ⚠️⚠️

  - Read the CONTRIBUTING.md guide and make sure you've followed all the steps given.
  - Ensure that the code is up-to-date with the `main` branch.
  - Provide or update documentation for any feature added by your pull request.
  - Provide relevant tests for your feature or bug fix.

  ❗️ Also: ❗️

  Please name your pull request {development-type}/{short-description}.
  For example: feature/read-tiff-files
-->

### Description of Changes

This makes it so that errors are not rendered directly as React children. This doesn't work and causes a second error. As noted in the TODO, this whole error display is a stopgap, but worth fixing for now.
