### PR TITLE
feature/events-page

### DIFF
--- a/src/assets/LocalizedStrings.tsx
+++ b/src/assets/LocalizedStrings.tsx
@@ -15,7 +15,7 @@ import LocalizedStrings, { LocalizedStringsMethods } from "react-localization";
  **/
 export interface MasterStringsList extends LocalizedStringsMethods {
   [propName: string]: any;
-  tags: string;
+  keywords: string;
   same: string;
   select_language: string;
   committee: string;

--- a/src/assets/strings/de.ts
+++ b/src/assets/strings/de.ts
@@ -12,7 +12,7 @@ const de = {
   en: "English",
   es: "Español",
   de: "Deutsche",
-  tags: "Stichworte",
+  keywords: "Schlüsselwörter",
   select_language: "Sprache auswählen",
   same: "gleich",
   committee: "Komitee",

--- a/src/assets/strings/en.ts
+++ b/src/assets/strings/en.ts
@@ -11,7 +11,7 @@ const en = {
   en: "English",
   es: "Español",
   de: "Deutsche",
-  tags: "Tags",
+  keywords: "Keywords",
   select_language: "Select Language",
   same: "same",
   committee: "Committee",

--- a/src/assets/strings/es.ts
+++ b/src/assets/strings/es.ts
@@ -11,7 +11,7 @@ const es = {
   en: "English",
   es: "Español",
   de: "Deutsche",
-  tags: "Etiquetas",
+  keywords: "Palabras clave",
   select_language: "Seleccione el Idioma",
   same: "Mismo",
   committee: "Comité",

--- a/src/components/Cards/LegislationCard/LegislationCard.tsx
+++ b/src/components/Cards/LegislationCard/LegislationCard.tsx
@@ -53,7 +53,7 @@ const LegislationCard: FC<LegislationCardProps> = ({
           <p className="mzp-c-card-meta">{status}</p>
           <StatusIconContainer>{statusIcon}</StatusIconContainer>
           <p className="mzp-c-card-desc">{date}</p>
-          <p className="mzp-c-card-meta">{strings.tags}</p>
+          <p className="mzp-c-card-meta">{strings.keywords}</p>
           <p className="mzp-c-card-desc">{tagString}</p>
         </div>
       </div>

--- a/src/components/Cards/LegislationCard/LegislationCard.tsx
+++ b/src/components/Cards/LegislationCard/LegislationCard.tsx
@@ -33,7 +33,7 @@ const LegislationCard: FC<LegislationCardProps> = ({
   date,
   tags,
 }: LegislationCardProps) => {
-  const tagString = tags.join(TAG_CONNECTOR);
+  const tagString = tags.map((tag) => tag.toLowerCase()).join(TAG_CONNECTOR);
 
   let statusIcon;
 

--- a/src/components/Cards/MeetingCard/MeetingCard.stories.tsx
+++ b/src/components/Cards/MeetingCard/MeetingCard.stories.tsx
@@ -12,7 +12,8 @@ const Template: Story<MeetingCardProps> = (args) => <MeetingCard {...args} />;
 
 export const meeting = Template.bind({});
 meeting.args = {
-  imgSrc: "https://mynorthwest.com/wp-content/uploads/2016/05/arena2-1.jpg",
+  staticImgSrc: "https://mynorthwest.com/wp-content/uploads/2016/05/arena2-1.jpg",
+  hoverImgSrc: "https://mynorthwest.com/wp-content/uploads/2016/05/arena2-1.jpg",
   imgAlt: "Citizen presenting at a select budget committee meeting",
   meetingDate: "June 9th, 2020",
   committee: "Select Budget",
@@ -21,7 +22,8 @@ meeting.args = {
 
 export const meetingSearchResult = Template.bind({});
 meetingSearchResult.args = {
-  imgSrc: "https://mynorthwest.com/wp-content/uploads/2016/05/arena2-1.jpg",
+  staticImgSrc: "https://mynorthwest.com/wp-content/uploads/2016/05/arena2-1.jpg",
+  hoverImgSrc: "https://mynorthwest.com/wp-content/uploads/2016/05/arena2-1.jpg",
   imgAlt: "Citizen presenting at a select budget committee meeting",
   meetingDate: "June 9th, 2020",
   committee: "Select Budget",

--- a/src/components/Cards/MeetingCard/MeetingCard.tsx
+++ b/src/components/Cards/MeetingCard/MeetingCard.tsx
@@ -64,7 +64,7 @@ const MeetingCard = ({
               }}
             >{`"${excerpt}"`}</p>
           ) : null}
-          <p className="mzp-c-card-meta">{strings.tags}</p>
+          <p className="mzp-c-card-meta">{strings.keywords}</p>
           <p className="mzp-c-card-desc">{tagString}</p>
         </div>
       </div>

--- a/src/components/Cards/MeetingCard/MeetingCard.tsx
+++ b/src/components/Cards/MeetingCard/MeetingCard.tsx
@@ -46,7 +46,7 @@ const MeetingCard = ({
 
   return (
     <Meeting className="mzp-c-card mzp-has-aspect-16-9">
-      <div>
+      <div className="mzp-c-card-block-link">
         <div className="mzp-c-card-media-wrapper">
           <img className="mzp-c-card-image" src={staticImgSrc} alt={imgAlt} />
           <img className="mzp-c-card-image" src={hoverImgSrc} alt={imgAlt} />

--- a/src/components/Cards/MeetingCard/MeetingCard.tsx
+++ b/src/components/Cards/MeetingCard/MeetingCard.tsx
@@ -7,9 +7,9 @@ import { strings } from "../../../assets/LocalizedStrings";
 export type MeetingCardProps = {
   /** The static poster image src of the event */
   staticImgSrc: string;
-  /** The animated post image src of the event */
+  /** The animated poster image src of the event */
   hoverImgSrc: string;
-  /** The alternative title of the post image */
+  /** The alternative title of the poster image */
   imgAlt: string;
   /** The event's date */
   meetingDate: string;

--- a/src/components/Cards/MeetingCard/MeetingCard.tsx
+++ b/src/components/Cards/MeetingCard/MeetingCard.tsx
@@ -42,7 +42,7 @@ const MeetingCard = ({
   tags,
   excerpt,
 }: MeetingCardProps) => {
-  const tagString = tags.join(TAG_CONNECTOR);
+  const tagString = tags.map((tag) => tag.toLowerCase()).join(TAG_CONNECTOR);
 
   return (
     <Meeting className="mzp-c-card mzp-has-aspect-16-9">

--- a/src/components/Cards/MeetingCard/MeetingCard.tsx
+++ b/src/components/Cards/MeetingCard/MeetingCard.tsx
@@ -30,6 +30,7 @@ const Meeting = styled.section({
   "& img:last-of-type, &:hover img:first-of-type": {
     visibility: "hidden",
   },
+  marginBottom: 0,
 });
 
 const MeetingCard = ({

--- a/src/components/Cards/MeetingCard/MeetingCard.tsx
+++ b/src/components/Cards/MeetingCard/MeetingCard.tsx
@@ -45,7 +45,7 @@ const MeetingCard = ({
   const tagString = tags.join(TAG_CONNECTOR);
 
   return (
-    <Meeting className="mzp-c-card mzp-c-card-medium mzp-has-aspect-16-9">
+    <Meeting className="mzp-c-card mzp-has-aspect-16-9">
       <div>
         <div className="mzp-c-card-media-wrapper">
           <img className="mzp-c-card-image" src={staticImgSrc} alt={imgAlt} />

--- a/src/components/Cards/MeetingCard/MeetingCard.tsx
+++ b/src/components/Cards/MeetingCard/MeetingCard.tsx
@@ -45,7 +45,7 @@ const MeetingCard = ({
   const tagString = tags.join(TAG_CONNECTOR);
 
   return (
-    <Meeting className="mzp-c-card mzp-has-aspect-16-9">
+    <Meeting className="mzp-c-card mzp-c-card-medium mzp-has-aspect-16-9">
       <div>
         <div className="mzp-c-card-media-wrapper">
           <img className="mzp-c-card-image" src={staticImgSrc} alt={imgAlt} />

--- a/src/components/Cards/MeetingCard/MeetingCard.tsx
+++ b/src/components/Cards/MeetingCard/MeetingCard.tsx
@@ -1,11 +1,14 @@
 import React from "react";
+import styled from "@emotion/styled";
 import { TAG_CONNECTOR } from "../../../constants/StyleConstants";
 import "@mozilla-protocol/core/protocol/css/protocol.css";
 import { strings } from "../../../assets/LocalizedStrings";
 
 export type MeetingCardProps = {
-  /** The poster image src of the event */
-  imgSrc: string;
+  /** The static poster image src of the event */
+  staticImgSrc: string;
+  /** The animated post image src of the event */
+  hoverImgSrc: string;
   /** The alternative title of the post image */
   imgAlt: string;
   /** The event's date */
@@ -18,8 +21,20 @@ export type MeetingCardProps = {
   excerpt?: string;
 };
 
+const Meeting = styled.section({
+  // show the first img and second img on hover
+  "& img:first-of-type, &:hover img:last-of-type": {
+    visibility: "visible",
+  },
+  // hide the second img and first img on hover
+  "& img:last-of-type, &:hover img:first-of-type": {
+    visibility: "hidden",
+  },
+});
+
 const MeetingCard = ({
-  imgSrc,
+  staticImgSrc,
+  hoverImgSrc,
   imgAlt,
   meetingDate,
   committee,
@@ -29,10 +44,11 @@ const MeetingCard = ({
   const tagString = tags.join(TAG_CONNECTOR);
 
   return (
-    <section className="mzp-c-card mzp-has-aspect-16-9">
+    <Meeting className="mzp-c-card mzp-has-aspect-16-9">
       <div>
         <div className="mzp-c-card-media-wrapper">
-          <img className="mzp-c-card-image" src={imgSrc} alt={imgAlt} />
+          <img className="mzp-c-card-image" src={staticImgSrc} alt={imgAlt} />
+          <img className="mzp-c-card-image" src={hoverImgSrc} alt={imgAlt} />
         </div>
         <div className="mzp-c-card-content">
           <div className="mzp-c-card-tag">{strings.committee}</div>
@@ -51,7 +67,7 @@ const MeetingCard = ({
           <p className="mzp-c-card-desc">{tagString}</p>
         </div>
       </div>
-    </section>
+    </Meeting>
   );
 };
 

--- a/src/components/Filters/EventsFilter/EventsFilter.tsx
+++ b/src/components/Filters/EventsFilter/EventsFilter.tsx
@@ -19,6 +19,9 @@ const Filters = styled.div({
   [`@media (min-width:${screenWidths.tablet})`]: {
     flexDirection: "row",
     flexWrap: "wrap",
+    "& > div:last-of-type": {
+      marginLeft: "auto",
+    },
   },
 });
 

--- a/src/components/Filters/EventsFilter/EventsFilter.tsx
+++ b/src/components/Filters/EventsFilter/EventsFilter.tsx
@@ -37,7 +37,7 @@ const EventsFilter: FC<EventsFilterProps> = ({
   filters,
   sortOptions,
   handlePopupClose,
-}) => {
+}: EventsFilterProps) => {
   const [committeeFilter, dateRangeFilter, sortFilter] = filters;
   const [committeeQuery, setCommitteeQuery] = useState("");
 
@@ -67,6 +67,8 @@ const EventsFilter: FC<EventsFilterProps> = ({
           setPopupIsOpen={committeeFilter.setPopupIsOpen}
           handlePopupClose={handlePopupClose}
           closeOnChange={false}
+          hasRequiredError={committeeFilter.hasRequiredError()}
+          hasLimitError={committeeFilter.hasLimitError()}
         >
           <SelectTextFilterOptions
             name={committeeFilter.name}
@@ -75,6 +77,8 @@ const EventsFilter: FC<EventsFilterProps> = ({
             options={getCommitteeNameOptions()}
             optionQuery={committeeQuery}
             setOptionQuery={setCommitteeQuery}
+            hasRequiredError={committeeFilter.hasRequiredError()}
+            hasLimitError={committeeFilter.hasLimitError()}
           />
         </FilterPopup>
       </div>

--- a/src/components/Filters/EventsFilter/EventsFilter.tsx
+++ b/src/components/Filters/EventsFilter/EventsFilter.tsx
@@ -67,7 +67,6 @@ const EventsFilter: FC<EventsFilterProps> = ({
           setPopupIsOpen={committeeFilter.setPopupIsOpen}
           handlePopupClose={handlePopupClose}
           closeOnChange={false}
-          hasRequiredError={committeeFilter.hasRequiredError()}
           hasLimitError={committeeFilter.hasLimitError()}
         >
           <SelectTextFilterOptions
@@ -77,7 +76,6 @@ const EventsFilter: FC<EventsFilterProps> = ({
             options={getCommitteeNameOptions()}
             optionQuery={committeeQuery}
             setOptionQuery={setCommitteeQuery}
-            hasRequiredError={committeeFilter.hasRequiredError()}
             hasLimitError={committeeFilter.hasLimitError()}
             limit={committeeFilter.limit}
           />

--- a/src/components/Filters/EventsFilter/EventsFilter.tsx
+++ b/src/components/Filters/EventsFilter/EventsFilter.tsx
@@ -1,0 +1,113 @@
+import React, { FC, useState } from "react";
+import styled from "@emotion/styled";
+
+import Body from "../../../models/Body";
+
+import { FilterPopup } from "../FilterPopup";
+import { Filter } from "../useFilter";
+import { SelectDateRange } from "../SelectDateRange";
+import { SelectSorting } from "../SelectSorting";
+import { SortOption } from "../SelectSorting/getSortingText";
+import { SelectTextFilterOptions } from "../SelectTextFilterOptions";
+
+import { screenWidths } from "../../../styles/mediaBreakpoints";
+
+const Filters = styled.div({
+  display: "flex",
+  flexDirection: "column",
+  gap: 4,
+  [`@media (min-width:${screenWidths.tablet})`]: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+  },
+});
+
+interface EventsFilterProps {
+  allBodies: Body[];
+  filters: Filter<any>[];
+  sortOptions: SortOption[];
+  handlePopupClose(): void;
+}
+
+const EventsFilter: FC<EventsFilterProps> = ({
+  allBodies,
+  filters,
+  sortOptions,
+  handlePopupClose,
+}) => {
+  const [committeeFilter, dateRangeFilter, sortFilter] = filters;
+  const [committeeQuery, setCommitteeQuery] = useState("");
+
+  const getCommitteeNameOptions = () => {
+    return allBodies.map((body) => {
+      return {
+        name: body.id as string,
+        label: body.name as string,
+        disabled: false,
+      };
+    });
+  };
+
+  const handleSortingPopupClose = () => {
+    sortFilter.setPopupIsOpen(false);
+    handlePopupClose();
+  };
+
+  return (
+    <Filters>
+      <div>
+        <FilterPopup
+          clear={committeeFilter.clear}
+          getTextRep={committeeFilter.getTextRep}
+          isActive={committeeFilter.isActive}
+          popupIsOpen={committeeFilter.popupIsOpen}
+          setPopupIsOpen={committeeFilter.setPopupIsOpen}
+          handlePopupClose={handlePopupClose}
+          closeOnChange={false}
+        >
+          <SelectTextFilterOptions
+            name={committeeFilter.name}
+            state={committeeFilter.state}
+            update={committeeFilter.update}
+            options={getCommitteeNameOptions()}
+            optionQuery={committeeQuery}
+            setOptionQuery={setCommitteeQuery}
+          />
+        </FilterPopup>
+      </div>
+      <div>
+        <FilterPopup
+          clear={dateRangeFilter.clear}
+          getTextRep={dateRangeFilter.getTextRep}
+          isActive={dateRangeFilter.isActive}
+          popupIsOpen={dateRangeFilter.popupIsOpen}
+          setPopupIsOpen={dateRangeFilter.setPopupIsOpen}
+          handlePopupClose={handlePopupClose}
+          closeOnChange={false}
+        >
+          <SelectDateRange state={dateRangeFilter.state} update={dateRangeFilter.update} />
+        </FilterPopup>
+      </div>
+      <div>
+        <FilterPopup
+          clear={sortFilter.clear}
+          getTextRep={sortFilter.getTextRep}
+          isActive={sortFilter.isActive}
+          popupIsOpen={sortFilter.popupIsOpen}
+          setPopupIsOpen={sortFilter.setPopupIsOpen}
+          handlePopupClose={handlePopupClose}
+          closeOnChange={true}
+        >
+          <SelectSorting
+            sortOptions={sortOptions}
+            state={sortFilter.state}
+            update={sortFilter.update}
+            onPopupClose={handleSortingPopupClose}
+          />
+        </FilterPopup>
+      </div>
+    </Filters>
+  );
+};
+
+export default EventsFilter;

--- a/src/components/Filters/EventsFilter/EventsFilter.tsx
+++ b/src/components/Filters/EventsFilter/EventsFilter.tsx
@@ -60,6 +60,7 @@ const EventsFilter: FC<EventsFilterProps> = ({
     <Filters>
       <div>
         <FilterPopup
+          name={committeeFilter.name}
           clear={committeeFilter.clear}
           getTextRep={committeeFilter.getTextRep}
           isActive={committeeFilter.isActive}
@@ -68,6 +69,7 @@ const EventsFilter: FC<EventsFilterProps> = ({
           handlePopupClose={handlePopupClose}
           closeOnChange={false}
           hasLimitError={committeeFilter.hasLimitError()}
+          limit={committeeFilter.limit}
         >
           <SelectTextFilterOptions
             name={committeeFilter.name}
@@ -76,13 +78,12 @@ const EventsFilter: FC<EventsFilterProps> = ({
             options={getCommitteeNameOptions()}
             optionQuery={committeeQuery}
             setOptionQuery={setCommitteeQuery}
-            hasLimitError={committeeFilter.hasLimitError()}
-            limit={committeeFilter.limit}
           />
         </FilterPopup>
       </div>
       <div>
         <FilterPopup
+          name={dateRangeFilter.name}
           clear={dateRangeFilter.clear}
           getTextRep={dateRangeFilter.getTextRep}
           isActive={dateRangeFilter.isActive}
@@ -96,6 +97,7 @@ const EventsFilter: FC<EventsFilterProps> = ({
       </div>
       <div>
         <FilterPopup
+          name={sortFilter.name}
           clear={sortFilter.clear}
           getTextRep={sortFilter.getTextRep}
           isActive={sortFilter.isActive}

--- a/src/components/Filters/EventsFilter/EventsFilter.tsx
+++ b/src/components/Filters/EventsFilter/EventsFilter.tsx
@@ -79,6 +79,7 @@ const EventsFilter: FC<EventsFilterProps> = ({
             setOptionQuery={setCommitteeQuery}
             hasRequiredError={committeeFilter.hasRequiredError()}
             hasLimitError={committeeFilter.hasLimitError()}
+            limit={committeeFilter.limit}
           />
         </FilterPopup>
       </div>

--- a/src/components/Filters/EventsFilter/index.ts
+++ b/src/components/Filters/EventsFilter/index.ts
@@ -1,0 +1,1 @@
+export { default as EventsFilter } from "./EventsFilter";

--- a/src/components/Filters/FilterPopup/FilterPopup.stories.tsx
+++ b/src/components/Filters/FilterPopup/FilterPopup.stories.tsx
@@ -3,11 +3,12 @@ import React from "react";
 import { action } from "@storybook/addon-actions";
 import { Story, Meta } from "@storybook/react";
 
+import { ORDER_DIRECTION } from "../../../networking/constants";
+
+import FilterPopup, { FilterPopupProps } from "./FilterPopup";
 import { SelectDateRange } from "../SelectDateRange";
 import { SelectSorting } from "../SelectSorting";
 import { SelectTextFilterOptions } from "../SelectTextFilterOptions";
-
-import FilterPopup, { FilterPopupProps } from "./FilterPopup";
 
 export default {
   component: FilterPopup,
@@ -45,14 +46,14 @@ selectSorting.args = {
     <SelectSorting
       state={{
         by: "value",
-        order: "desc",
+        order: ORDER_DIRECTION.desc,
         label: "Most relevant",
       }}
       update={action("update-sorting-state")}
       sortOptions={[
-        { by: "value", order: "desc", label: "Most relevant" },
-        { by: "date", order: "desc", label: "Newest first" },
-        { by: "date", order: "asc", label: "Oldest first" },
+        { by: "value", order: ORDER_DIRECTION.desc, label: "Most relevant" },
+        { by: "date", order: ORDER_DIRECTION.desc, label: "Newest first" },
+        { by: "date", order: ORDER_DIRECTION.asc, label: "Oldest first" },
       ]}
       onPopupClose={action("on-popup-close")}
     />

--- a/src/components/Filters/FilterPopup/FilterPopup.test.tsx
+++ b/src/components/Filters/FilterPopup/FilterPopup.test.tsx
@@ -31,7 +31,7 @@ describe("FilterPopup", () => {
       </FilterPopup>
     );
     expect(setPopupIsOpenMock).toHaveBeenCalledTimes(0);
-    filterPopupMount.find("StyledSelect").simulate("click");
+    filterPopupMount.find("TriggerButton").simulate("click");
     expect(setPopupIsOpenMock).toHaveBeenCalledTimes(1);
   });
 
@@ -56,14 +56,14 @@ describe("FilterPopup", () => {
 
     test("Calls onClearFilter callback", () => {
       expect(clearMock).toHaveBeenCalledTimes(0);
-      filterPopup.find(".mzp-t-neutral").simulate("click");
+      filterPopup.find(".mzp-t-md.mzp-t-neutral").simulate("click");
       expect(clearMock).toHaveBeenCalledTimes(1);
     });
 
     test("Calls handlePopupClose callback", () => {
       expect(setPopupIsOpenMock).toHaveBeenCalledTimes(0);
       expect(handlePopupCloseMock).toHaveBeenCalledTimes(0);
-      filterPopup.find(".mzp-t-product").simulate("click");
+      filterPopup.find(".mzp-t-md.mzp-t-product").simulate("click");
       expect(setPopupIsOpenMock).toHaveBeenCalledTimes(1);
       expect(handlePopupCloseMock).toHaveBeenCalledTimes(1);
     });

--- a/src/components/Filters/FilterPopup/FilterPopup.test.tsx
+++ b/src/components/Filters/FilterPopup/FilterPopup.test.tsx
@@ -56,14 +56,14 @@ describe("FilterPopup", () => {
 
     test("Calls onClearFilter callback", () => {
       expect(clearMock).toHaveBeenCalledTimes(0);
-      filterPopup.find("MozillaNeutralButton").simulate("click");
+      filterPopup.find(".mzp-t-neutral").simulate("click");
       expect(clearMock).toHaveBeenCalledTimes(1);
     });
 
     test("Calls handlePopupClose callback", () => {
       expect(setPopupIsOpenMock).toHaveBeenCalledTimes(0);
       expect(handlePopupCloseMock).toHaveBeenCalledTimes(0);
-      filterPopup.find("MozillaProductButton").simulate("click");
+      filterPopup.find(".mzp-t-product").simulate("click");
       expect(setPopupIsOpenMock).toHaveBeenCalledTimes(1);
       expect(handlePopupCloseMock).toHaveBeenCalledTimes(1);
     });

--- a/src/components/Filters/FilterPopup/FilterPopup.test.tsx
+++ b/src/components/Filters/FilterPopup/FilterPopup.test.tsx
@@ -19,6 +19,7 @@ describe("FilterPopup", () => {
   test("Calls setPopupisOpen callback to open popup", () => {
     const filterPopupMount: ReactWrapper<FilterPopupProps> = mount(
       <FilterPopup
+        name="test"
         clear={clearMock}
         getTextRep={getTextRepMock}
         isActive={isActiveMock}
@@ -41,6 +42,7 @@ describe("FilterPopup", () => {
     beforeEach(() => {
       filterPopup = shallow(
         <FilterPopup
+          name="test"
           clear={clearMock}
           getTextRep={getTextRepMock}
           isActive={isActiveMock}

--- a/src/components/Filters/FilterPopup/FilterPopup.tsx
+++ b/src/components/Filters/FilterPopup/FilterPopup.tsx
@@ -1,7 +1,10 @@
 import React, { Dispatch, FunctionComponent, Fragment, ReactNode, useRef } from "react";
 import styled from "@emotion/styled";
-import { strings } from "../../../assets/LocalizedStrings";
+import { some } from "lodash";
 import { Icon, Popup } from "semantic-ui-react";
+
+import { strings } from "../../../assets/LocalizedStrings";
+
 import "@mozilla-protocol/core/protocol/css/protocol.css";
 
 // Matching the styles of a Mozilla Protocol select element
@@ -95,6 +98,10 @@ export interface FilterPopupProps {
   closeOnChange: boolean;
   /**React Child Node. One of the filter components such as SelectDateRange, SelectTextFilterOptions, SelectSorting. */
   children: ReactNode;
+  /**At least one option is selected regarding the filter? */
+  hasRequiredError?: boolean;
+  /**The number of selected options exceeded the allowed limit of selected options? */
+  hasLimitError?: boolean;
 }
 
 /**
@@ -110,6 +117,8 @@ const FilterPopup: FunctionComponent<FilterPopupProps> = ({
   handlePopupClose,
   closeOnChange,
   children,
+  hasRequiredError,
+  hasLimitError,
 }: FilterPopupProps) => {
   const mountNodeRef = useRef<HTMLDivElement>(null);
 
@@ -127,6 +136,8 @@ const FilterPopup: FunctionComponent<FilterPopupProps> = ({
   const onClearFilter = () => {
     clear();
   };
+
+  const hasError = some([hasRequiredError, hasLimitError]);
 
   return (
     <Fragment>
@@ -151,7 +162,7 @@ const FilterPopup: FunctionComponent<FilterPopupProps> = ({
               <MozillaNeutralButton disabled={!isActive()} onClick={onClearFilter}>
                 <Icon name="remove" /> {strings.clear}
               </MozillaNeutralButton>
-              <MozillaProductButton onClick={onPopupClose}>
+              <MozillaProductButton disabled={hasError} onClick={onPopupClose}>
                 <Icon name="checkmark" /> {strings.save}
               </MozillaProductButton>
             </ButtonContainer>

--- a/src/components/Filters/FilterPopup/FilterPopup.tsx
+++ b/src/components/Filters/FilterPopup/FilterPopup.tsx
@@ -133,7 +133,7 @@ const FilterPopup: FunctionComponent<FilterPopupProps> = ({
       <StyledPopup
         basic
         flowing
-        content={mountNodeRef.current}
+        context={mountNodeRef.current || undefined}
         on="click"
         onClose={onPopupClose}
         onOpen={onPopupOpen}

--- a/src/components/Filters/FilterPopup/FilterPopup.tsx
+++ b/src/components/Filters/FilterPopup/FilterPopup.tsx
@@ -1,29 +1,21 @@
 import React, { Dispatch, FunctionComponent, Fragment, ReactNode, useRef } from "react";
 import styled from "@emotion/styled";
 import { some } from "lodash";
-import { Icon, Popup } from "semantic-ui-react";
+import { Popup } from "semantic-ui-react";
+
+import ChevronDownIcon from "../../Shared/ChevronDownIcon";
 
 import { strings } from "../../../assets/LocalizedStrings";
 
 import "@mozilla-protocol/core/protocol/css/protocol.css";
 
-// Matching the styles of a Mozilla Protocol select element
-// https://protocol.mozilla.org/patterns/atoms/forms.html#select
-const StyledSelect = styled.button({
-  color: "rgba(0, 0, 0, 1) !important",
-  boxShadow: "none !important",
-  padding: "8px calc(1.5em + 16px) 8px 8px !important",
-  borderRadius: "4px !important",
-  border: "2px solid #9595a2 !important",
-  backgroundImage: `url("data:image/svg+xml,%3Csvg width='24px' height='24px' viewBox='0 0 24 24' xmlns='http://www.w3.org/2000/svg'%3E%3Cg stroke='none' stroke-width='1' fill='none' fill-rule='evenodd' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline stroke='%239595a3' stroke-width='2' points='5 9 12 16 19 9'%3E%3C/polyline%3E%3C/g%3E%3C/svg%3E"), linear-gradient(to bottom, #ffffff 0%, #ffffff 100%)`,
-  backgroundPosition: "right 8px top 50% !important",
-  backgroundRepeat: "no-repeat, repeat !important",
-  display: "block !important",
-  width: "100% !important",
-  textOverflow: "ellipsis !important",
-  lineHeight: "1.25 !important",
+const TriggerButton = styled.button({
+  display: "flex",
+  justifyContent: "space-between",
+  alignItems: "center",
+  width: "100%",
 });
-StyledSelect.displayName = "StyledSelect";
+TriggerButton.displayName = "TriggerButton";
 
 const StyledPopup = styled(Popup)({
   // limit the width of the popup
@@ -131,7 +123,14 @@ const FilterPopup: FunctionComponent<FilterPopupProps> = ({
         offset={[0, -5]}
         position="bottom left"
         positionFixed={true}
-        trigger={<StyledSelect>{getTextRep()}</StyledSelect>}
+        trigger={
+          <TriggerButton className="mzp-c-button mzp-t-lg mzp-t-neutral">
+            {getTextRep()}
+            <div style={{ marginLeft: 24, width: 16, height: 16 }}>
+              <ChevronDownIcon />
+            </div>
+          </TriggerButton>
+        }
       >
         <PopupContainer>
           <ContentContainer>{children}</ContentContainer>

--- a/src/components/Filters/FilterPopup/FilterPopup.tsx
+++ b/src/components/Filters/FilterPopup/FilterPopup.tsx
@@ -1,4 +1,12 @@
-import React, { Dispatch, FunctionComponent, Fragment, ReactNode, useRef, useMemo } from "react";
+import React, {
+  Dispatch,
+  FunctionComponent,
+  Fragment,
+  ReactNode,
+  useRef,
+  useMemo,
+  SetStateAction,
+} from "react";
 import styled from "@emotion/styled";
 import { some } from "lodash";
 import { Popup } from "semantic-ui-react";
@@ -63,7 +71,7 @@ export interface FilterPopupProps {
   /**Whether the filter popup is open. */
   popupIsOpen: boolean;
   /**React Dispatch callback to update the popupIsOpen state. */
-  setPopupIsOpen: Dispatch<boolean>;
+  setPopupIsOpen: Dispatch<SetStateAction<boolean>>;
   /**Callback to handle filter popup closing. */
   handlePopupClose?(): void;
   /**Whether or not the popup should close when a value is selected. */
@@ -111,8 +119,8 @@ const FilterPopup: FunctionComponent<FilterPopupProps> = ({
     return errors;
   }, [hasRequiredError, hasLimitError, name, limit]);
 
-  const onPopupOpen = () => {
-    setPopupIsOpen(true);
+  const togglePopupIsOpen = () => {
+    setPopupIsOpen((prev) => !prev);
   };
 
   const onPopupClose = () => {
@@ -133,15 +141,16 @@ const FilterPopup: FunctionComponent<FilterPopupProps> = ({
         flowing
         context={mountNodeRef.current || undefined}
         on="click"
-        onClose={onPopupClose}
-        onOpen={onPopupOpen}
         open={popupIsOpen}
         pinned={true}
         offset={[0, -5]}
         position="bottom left"
         positionFixed={true}
         trigger={
-          <TriggerButton className="mzp-c-button mzp-t-lg mzp-t-neutral">
+          <TriggerButton
+            className="mzp-c-button mzp-t-lg mzp-t-neutral"
+            onClick={togglePopupIsOpen}
+          >
             {getTextRep()}
             <div style={{ marginLeft: 24, width: 16, height: 16 }}>
               <ChevronDownIcon />

--- a/src/components/Filters/FilterPopup/FilterPopup.tsx
+++ b/src/components/Filters/FilterPopup/FilterPopup.tsx
@@ -9,7 +9,7 @@ import "@mozilla-protocol/core/protocol/css/protocol.css";
 
 // Matching the styles of a Mozilla Protocol select element
 // https://protocol.mozilla.org/patterns/atoms/forms.html#select
-const StyledSelect = styled.div({
+const StyledSelect = styled.button({
   color: "rgba(0, 0, 0, 1) !important",
   boxShadow: "none !important",
   padding: "8px calc(1.5em + 16px) 8px 8px !important",
@@ -58,28 +58,6 @@ const ButtonContainer = styled.div({
   padding: ".833em 0 0",
 });
 ButtonContainer.displayName = "ButtonContainer";
-
-const MozillaProductButton = styled.button({
-  color: "#ffffff",
-  backgroundColor: "#0060df",
-  border: "2px solid #000000",
-  borderColor: "transparent",
-  borderRadius: "4px",
-  padding: "6px 24px",
-  fontSize: "0.875rem",
-});
-MozillaProductButton.displayName = "MozillaProductButton";
-
-const MozillaNeutralButton = styled.button({
-  color: "#5e5e72",
-  backgroundColor: "transparent",
-  border: "2px solid #000000",
-  borderColor: "#cdcdd4",
-  borderRadius: "4px",
-  padding: "6px 24px",
-  fontSize: "0.875rem",
-});
-MozillaNeutralButton.displayName = "MozillaNeutralButton";
 
 export interface FilterPopupProps {
   /**Callback to reset the filter state. */
@@ -159,12 +137,20 @@ const FilterPopup: FunctionComponent<FilterPopupProps> = ({
           <ContentContainer>{children}</ContentContainer>
           {!closeOnChange && (
             <ButtonContainer>
-              <MozillaNeutralButton disabled={!isActive()} onClick={onClearFilter}>
-                <Icon name="remove" /> {strings.clear}
-              </MozillaNeutralButton>
-              <MozillaProductButton disabled={hasError} onClick={onPopupClose}>
-                <Icon name="checkmark" /> {strings.save}
-              </MozillaProductButton>
+              <button
+                className="mzp-c-button mzp-t-md mzp-t-neutral"
+                disabled={!isActive()}
+                onClick={onClearFilter}
+              >
+                {strings.clear}
+              </button>
+              <button
+                className="mzp-c-button mzp-t-md mzp-t-product"
+                disabled={hasError}
+                onClick={onPopupClose}
+              >
+                {strings.save}
+              </button>
             </ButtonContainer>
           )}
         </PopupContainer>

--- a/src/components/Filters/FilterPopup/FilterPopup.tsx
+++ b/src/components/Filters/FilterPopup/FilterPopup.tsx
@@ -22,6 +22,11 @@ const TriggerButton = styled.button({
   justifyContent: "space-between",
   alignItems: "center",
   width: "100%",
+  "& > svg": {
+    marginLeft: 24,
+    width: 16,
+    height: 16,
+  },
 });
 TriggerButton.displayName = "TriggerButton";
 
@@ -152,9 +157,7 @@ const FilterPopup: FunctionComponent<FilterPopupProps> = ({
             onClick={togglePopupIsOpen}
           >
             {getTextRep()}
-            <div style={{ marginLeft: 24, width: 16, height: 16 }}>
-              <ChevronDownIcon />
-            </div>
+            <ChevronDownIcon />
           </TriggerButton>
         }
       >

--- a/src/components/Filters/SelectSorting/SelectSorting.stories.tsx
+++ b/src/components/Filters/SelectSorting/SelectSorting.stories.tsx
@@ -3,6 +3,8 @@ import React from "react";
 import { action } from "@storybook/addon-actions";
 import { Story, Meta } from "@storybook/react";
 
+import { ORDER_DIRECTION } from "../../../networking/constants";
+
 import SelectSorting, { SelectSortingProps } from "./SelectSorting";
 
 export default {
@@ -16,14 +18,14 @@ export const selectSorting = Template.bind({});
 selectSorting.args = {
   state: {
     by: "value",
-    order: "desc",
+    order: ORDER_DIRECTION.desc,
     label: "Most relevant",
   },
   update: action("update-sorting-state"),
   sortOptions: [
-    { by: "value", order: "desc", label: "Most relevant" },
-    { by: "date", order: "desc", label: "Newest first" },
-    { by: "date", order: "asc", label: "Oldest first" },
+    { by: "value", order: ORDER_DIRECTION.desc, label: "Most relevant" },
+    { by: "date", order: ORDER_DIRECTION.desc, label: "Newest first" },
+    { by: "date", order: ORDER_DIRECTION.asc, label: "Oldest first" },
   ],
   onPopupClose: action("on-popup-close"),
 };

--- a/src/components/Filters/SelectSorting/SelectSorting.test.tsx
+++ b/src/components/Filters/SelectSorting/SelectSorting.test.tsx
@@ -2,6 +2,8 @@ import React from "react";
 
 import { shallow, ShallowWrapper } from "enzyme";
 
+import { ORDER_DIRECTION } from "../../../networking/constants";
+
 import { SortOption } from "./getSortingText";
 import SelectSorting, { SelectSortingProps } from "./SelectSorting";
 
@@ -10,9 +12,9 @@ describe("SelectSorting", () => {
   const updateMock = jest.fn();
   const onPopupCloseMock = jest.fn();
   const sortOptions: SortOption[] = [
-    { by: "value", order: "desc", label: "Most relevant" },
-    { by: "date", order: "desc", label: "Newest first" },
-    { by: "date", order: "asc", label: "Oldest first" },
+    { by: "value", order: ORDER_DIRECTION.desc, label: "Most relevant" },
+    { by: "date", order: ORDER_DIRECTION.desc, label: "Newest first" },
+    { by: "date", order: ORDER_DIRECTION.asc, label: "Oldest first" },
   ];
 
   beforeEach(() => {

--- a/src/components/Filters/SelectSorting/getSortingText.test.ts
+++ b/src/components/Filters/SelectSorting/getSortingText.test.ts
@@ -1,3 +1,5 @@
+import { ORDER_DIRECTION } from "../../../networking/constants";
+
 import getSortingText from "./getSortingText";
 
 describe("getSortingText", () => {
@@ -8,7 +10,7 @@ describe("getSortingText", () => {
   });
 
   test("Returns correct label given sort state", () => {
-    const sortState = { by: "value", order: "desc", label: "Most relevant" };
+    const sortState = { by: "value", order: ORDER_DIRECTION.desc, label: "Most relevant" };
     const textRep = getSortingText(sortState, defaultText);
     expect(textRep).toEqual(sortState.label);
   });

--- a/src/components/Filters/SelectSorting/getSortingText.ts
+++ b/src/components/Filters/SelectSorting/getSortingText.ts
@@ -1,10 +1,11 @@
 import { FilterState } from "../reducer";
+import { ORDER_DIRECTION } from "../../../networking/constants";
 
 export interface SortOption {
   /**The field to sort by */
   by: string;
   /**The order to sort by */
-  order: string;
+  order: ORDER_DIRECTION;
   /**The label of the sort option */
   label: string;
 }

--- a/src/components/Filters/SelectTextFilterOptions/SelectTextFilterOptions.tsx
+++ b/src/components/Filters/SelectTextFilterOptions/SelectTextFilterOptions.tsx
@@ -73,7 +73,7 @@ const SelectTextFilterOptions: FunctionComponent<SelectTextFilterOptionsProps> =
   return (
     <form className="mzp-c-form">
       {options.length > 5 && setOptionQuery && (
-        <div className="mzp-c-field">
+        <div className="mzp-c-field mzp-l-stretch">
           <label className="mzp-c-field-label" htmlFor="form-input-control-search-filter">
             {`Search ${name} Options`}
           </label>

--- a/src/components/Filters/SelectTextFilterOptions/SelectTextFilterOptions.tsx
+++ b/src/components/Filters/SelectTextFilterOptions/SelectTextFilterOptions.tsx
@@ -1,5 +1,4 @@
 import React, { ChangeEvent, Dispatch, FunctionComponent, useMemo } from "react";
-import { some } from "lodash";
 
 import { FilterState } from "../reducer";
 
@@ -33,12 +32,6 @@ export interface SelectTextFilterOptionsProps {
   optionQuery?: string;
   /**React Dispatch callback to update the search string state. */
   setOptionQuery?: Dispatch<string>;
-  /**At least one option is selected regarding the filter? */
-  hasRequiredError?: boolean;
-  /**The number of selected options exceeded the allowed limit of selected options? */
-  hasLimitError?: boolean;
-  /**The number of allowed selected options. */
-  limit?: number;
 }
 
 const SelectTextFilterOptions: FunctionComponent<SelectTextFilterOptionsProps> = ({
@@ -48,9 +41,6 @@ const SelectTextFilterOptions: FunctionComponent<SelectTextFilterOptionsProps> =
   options,
   optionQuery,
   setOptionQuery,
-  hasRequiredError,
-  hasLimitError,
-  limit,
 }: SelectTextFilterOptionsProps) => {
   const onChange = (e: ChangeEvent<HTMLInputElement>) => {
     const filterOptionName = e.currentTarget.name;
@@ -79,19 +69,6 @@ const SelectTextFilterOptions: FunctionComponent<SelectTextFilterOptionsProps> =
     }
     return optionsInOrder;
   }, [options, optionQuery, setOptionQuery]);
-
-  const hasError = some([hasRequiredError, hasLimitError]);
-
-  const errors = useMemo(() => {
-    const errors: string[] = [];
-    if (hasRequiredError) {
-      errors.push(`Please select at least one ${name.toLowerCase()}.`);
-    }
-    if (hasLimitError) {
-      errors.push(`Please select only ${limit} or fewer ${name.toLowerCase()}s.`);
-    }
-    return errors;
-  }, [hasRequiredError, hasLimitError, name, limit]);
 
   return (
     <form className="mzp-c-form">
@@ -132,15 +109,6 @@ const SelectTextFilterOptions: FunctionComponent<SelectTextFilterOptionsProps> =
           ))}
         </div>
       </fieldset>
-      {hasError && (
-        <div className="mzp-c-form-errors">
-          <ul className="mzp-u-list-styled">
-            {errors.map((error) => (
-              <li key={error}>{error}</li>
-            ))}
-          </ul>
-        </div>
-      )}
     </form>
   );
 };

--- a/src/components/Filters/SelectTextFilterOptions/SelectTextFilterOptions.tsx
+++ b/src/components/Filters/SelectTextFilterOptions/SelectTextFilterOptions.tsx
@@ -37,6 +37,8 @@ export interface SelectTextFilterOptionsProps {
   hasRequiredError?: boolean;
   /**The number of selected options exceeded the allowed limit of selected options? */
   hasLimitError?: boolean;
+  /**The number of allowed selected options. */
+  limit?: number;
 }
 
 const SelectTextFilterOptions: FunctionComponent<SelectTextFilterOptionsProps> = ({
@@ -48,6 +50,7 @@ const SelectTextFilterOptions: FunctionComponent<SelectTextFilterOptionsProps> =
   setOptionQuery,
   hasRequiredError,
   hasLimitError,
+  limit,
 }: SelectTextFilterOptionsProps) => {
   const onChange = (e: ChangeEvent<HTMLInputElement>) => {
     const filterOptionName = e.currentTarget.name;
@@ -85,10 +88,10 @@ const SelectTextFilterOptions: FunctionComponent<SelectTextFilterOptionsProps> =
       errors.push(`Please select at least one ${name.toLowerCase()}.`);
     }
     if (hasLimitError) {
-      errors.push(`Please select only 10 or fewer ${name.toLowerCase()}s.`);
+      errors.push(`Please select only ${limit} or fewer ${name.toLowerCase()}s.`);
     }
     return errors;
-  }, [hasRequiredError, hasLimitError, name]);
+  }, [hasRequiredError, hasLimitError, name, limit]);
 
   return (
     <form className="mzp-c-form">

--- a/src/components/Filters/SelectTextFilterOptions/SelectTextFilterOptions.tsx
+++ b/src/components/Filters/SelectTextFilterOptions/SelectTextFilterOptions.tsx
@@ -1,4 +1,4 @@
-import React, { ChangeEvent, Dispatch, FunctionComponent } from "react";
+import React, { ChangeEvent, Dispatch, FunctionComponent, useCallback } from "react";
 import "@mozilla-protocol/core/protocol/css/protocol.css";
 import "@mozilla-protocol/core/protocol/css/protocol-components.css";
 import { FilterState } from "../reducer";
@@ -58,17 +58,20 @@ const SelectTextFilterOptions: FunctionComponent<SelectTextFilterOptionsProps> =
     }
   };
 
-  let optionsInOrder = [...options];
-  if (options.length > 5 && setOptionQuery) {
-    for (const option of options) {
-      option.disabled = !isSubstring(option.label, optionQuery || "");
-    }
+  const getOptionsInOrder = useCallback(() => {
+    let optionsInOrder = [...options];
+    if (options.length > 5 && setOptionQuery) {
+      for (const option of options) {
+        option.disabled = !isSubstring(option.label, optionQuery || "");
+      }
 
-    optionsInOrder = [
-      ...options.filter((option) => !option.disabled),
-      ...options.filter((option) => option.disabled),
-    ];
-  }
+      optionsInOrder = [
+        ...options.filter((option) => !option.disabled),
+        ...options.filter((option) => option.disabled),
+      ];
+    }
+    return optionsInOrder;
+  }, [options, optionQuery, setOptionQuery]);
 
   return (
     <form className="mzp-c-form">
@@ -88,7 +91,7 @@ const SelectTextFilterOptions: FunctionComponent<SelectTextFilterOptionsProps> =
       )}
       <fieldset className="mzp-c-field-set">
         <div className="mzp-c-choices">
-          {optionsInOrder.map((option) => (
+          {getOptionsInOrder().map((option) => (
             <div key={option.name} className="mzp-c-choice">
               <input
                 className="mzp-c-choice-control"

--- a/src/components/Filters/SelectTextFilterOptions/getSelectedOptions.ts
+++ b/src/components/Filters/SelectTextFilterOptions/getSelectedOptions.ts
@@ -5,8 +5,8 @@ import { FilterState } from "../reducer";
  * where the keys are the different options, and each value is a boolean(whether the option is selected).
  * @return {string[]} The list of selected options.
  */
-const getSelectedOptions = (checkboxes: FilterState<boolean>): string[] => {
-  return Object.keys(checkboxes).filter((k) => checkboxes[k]);
+const getSelectedOptions = (checkboxes: FilterState<any>): string[] => {
+  return Object.keys(checkboxes).filter((k) => checkboxes[k] === true);
 };
 
 export default getSelectedOptions;

--- a/src/components/Filters/useFilter.test.ts
+++ b/src/components/Filters/useFilter.test.ts
@@ -11,7 +11,12 @@ describe("useFilter", () => {
 
   test("Sets boolean filter state to all false", () => {
     const { result } = renderHook(() =>
-      useFilter<boolean>("test", { a: true, b: true }, false, textRepFuncMock)
+      useFilter<boolean>({
+        name: "test",
+        initialState: { a: true, b: true },
+        defaultDataValue: false,
+        textRepFunction: textRepFuncMock,
+      })
     );
     act(() => {
       result.current.clear();
@@ -24,7 +29,12 @@ describe("useFilter", () => {
     const keyName = "a";
     const newDataValue = false;
     const { result } = renderHook(() =>
-      useFilter<boolean>("test", { a: true, b: true }, false, textRepFuncMock)
+      useFilter<boolean>({
+        name: "test",
+        initialState: { a: true, b: true },
+        defaultDataValue: false,
+        textRepFunction: textRepFuncMock,
+      })
     );
     act(() => {
       result.current.update(keyName, newDataValue);
@@ -34,7 +44,12 @@ describe("useFilter", () => {
 
   test("Calls textRepFunc callback", () => {
     const { result } = renderHook(() =>
-      useFilter<boolean>("test", { a: false, b: false }, false, textRepFuncMock)
+      useFilter<boolean>({
+        name: "test",
+        initialState: { a: false, b: false },
+        defaultDataValue: false,
+        textRepFunction: textRepFuncMock,
+      })
     );
     result.current.getTextRep();
     expect(textRepFuncMock).toHaveBeenCalledTimes(1);
@@ -42,20 +57,37 @@ describe("useFilter", () => {
 
   describe("isActive for boolean filter", () => {
     test("Returns false for uninitialized state", () => {
-      const { result } = renderHook(() => useFilter<boolean>("test", {}, false, textRepFuncMock));
+      const { result } = renderHook(() =>
+        useFilter<boolean>({
+          name: "test",
+          initialState: {},
+          defaultDataValue: false,
+          textRepFunction: textRepFuncMock,
+        })
+      );
       expect(result.current.isActive()).toBe(false);
     });
 
     test("Returns false for no selected options", () => {
       const { result } = renderHook(() =>
-        useFilter<boolean>("test", { a: false, b: false }, false, textRepFuncMock)
+        useFilter<boolean>({
+          name: "test",
+          initialState: { a: false, b: false },
+          defaultDataValue: false,
+          textRepFunction: textRepFuncMock,
+        })
       );
       expect(result.current.isActive()).toBe(false);
     });
 
     test("Returns true for one selected option", () => {
       const { result } = renderHook(() =>
-        useFilter<boolean>("test", { a: true, b: false }, false, textRepFuncMock)
+        useFilter<boolean>({
+          name: "test",
+          initialState: { a: true, b: false },
+          defaultDataValue: false,
+          textRepFunction: textRepFuncMock,
+        })
       );
       expect(result.current.isActive()).toBe(true);
     });
@@ -66,7 +98,12 @@ describe("useFilter", () => {
       const prevState = {};
       const newState = { a: false, b: false };
       const { result } = renderHook(() =>
-        useFilter<boolean>("test", newState, false, textRepFuncMock)
+        useFilter<boolean>({
+          name: "test",
+          initialState: newState,
+          defaultDataValue: false,
+          textRepFunction: textRepFuncMock,
+        })
       );
       expect(result.current.isSameState(prevState)).toBe(true);
     });
@@ -75,7 +112,12 @@ describe("useFilter", () => {
       const prevState = {};
       const newState = { a: true, b: false };
       const { result } = renderHook(() =>
-        useFilter<boolean>("test", newState, false, textRepFuncMock)
+        useFilter<boolean>({
+          name: "test",
+          initialState: newState,
+          defaultDataValue: false,
+          textRepFunction: textRepFuncMock,
+        })
       );
       expect(result.current.isSameState(prevState)).toBe(false);
     });
@@ -84,7 +126,12 @@ describe("useFilter", () => {
       const prevState = { a: false };
       const newState = { a: false, b: true };
       const { result } = renderHook(() =>
-        useFilter<boolean>("test", newState, false, textRepFuncMock)
+        useFilter<boolean>({
+          name: "test",
+          initialState: newState,
+          defaultDataValue: false,
+          textRepFunction: textRepFuncMock,
+        })
       );
       expect(result.current.isSameState(prevState)).toBe(false);
     });
@@ -93,7 +140,12 @@ describe("useFilter", () => {
       const prevState = { a: false, b: false };
       const newState = { a: true, b: false };
       const { result } = renderHook(() =>
-        useFilter<boolean>("test", newState, false, textRepFuncMock)
+        useFilter<boolean>({
+          name: "test",
+          initialState: newState,
+          defaultDataValue: false,
+          textRepFunction: textRepFuncMock,
+        })
       );
       expect(result.current.isSameState(prevState)).toBe(false);
     });
@@ -102,7 +154,12 @@ describe("useFilter", () => {
       const prevState = { a: true, b: false };
       const newState = { a: false, b: false };
       const { result } = renderHook(() =>
-        useFilter<boolean>("test", newState, false, textRepFuncMock)
+        useFilter<boolean>({
+          name: "test",
+          initialState: newState,
+          defaultDataValue: false,
+          textRepFunction: textRepFuncMock,
+        })
       );
       expect(result.current.isSameState(prevState)).toBe(false);
     });
@@ -111,7 +168,12 @@ describe("useFilter", () => {
       const prevState = { a: true, b: true };
       const newState = { a: true, b: true };
       const { result } = renderHook(() =>
-        useFilter<boolean>("test", newState, false, textRepFuncMock)
+        useFilter<boolean>({
+          name: "test",
+          initialState: newState,
+          defaultDataValue: false,
+          textRepFunction: textRepFuncMock,
+        })
       );
       expect(result.current.isSameState(prevState)).toBe(true);
     });

--- a/src/components/Filters/useFilter.ts
+++ b/src/components/Filters/useFilter.ts
@@ -3,6 +3,8 @@ import { Dispatch, useReducer, useState } from "react";
 import { FILTER_CLEAR, FILTER_UPDATE } from "./actions";
 import createFilterReducer, { FilterState } from "./reducer";
 
+import { getSelectedOptions } from "./SelectTextFilterOptions";
+
 /**
  * The return type of useFilter hook
  */
@@ -25,15 +27,24 @@ export interface Filter<T> {
   isActive(): boolean;
   /**Return whether the other filter's state is the same as this filter's state */
   isSameState(otherState: FilterState<T>): boolean;
+  /**At least one option is selected regarding the filter? */
+  hasRequiredError(): boolean;
+  /**The number of selected options exceeded the allowed limit of selected options? */
+  hasLimitError(): boolean;
+}
+
+export interface UseFilterArg<T> {
+  name: string;
+  initialState: FilterState<T>;
+  defaultDataValue: T;
+  textRepFunction: (state: FilterState<T>, defaultText: string) => string;
+  isRequired?: boolean;
+  limit?: number;
 }
 /**Returns an object that encapsulates the filter's state with functions to update filter's state
  * and get other useful informations about the state. */
-function useFilter<T>(
-  name: string,
-  initialState: FilterState<T>,
-  defaultDataValue: T,
-  textRepFunction: (state: FilterState<T>, defaultText: string) => string
-): Filter<T> {
+function useFilter<T>(arg: UseFilterArg<T>): Filter<T> {
+  const { name, initialState, defaultDataValue, textRepFunction, isRequired, limit } = arg;
   const filterReducer = createFilterReducer<T>();
   const [state, dispatch] = useReducer(filterReducer, initialState);
   const [popupIsOpen, setPopupIsOpen] = useState(false);
@@ -81,6 +92,20 @@ function useFilter<T>(
     return true;
   };
 
+  const hasRequiredError = (): boolean => {
+    if (isRequired) {
+      return !isActive();
+    }
+    return false;
+  };
+
+  const hasLimitError = (): boolean => {
+    if (limit !== undefined) {
+      return getSelectedOptions(state).length > limit;
+    }
+    return false;
+  };
+
   return {
     name,
     state,
@@ -91,6 +116,8 @@ function useFilter<T>(
     getTextRep,
     isActive,
     isSameState,
+    hasRequiredError,
+    hasLimitError,
   };
 }
 

--- a/src/components/Filters/useFilter.ts
+++ b/src/components/Filters/useFilter.ts
@@ -31,6 +31,8 @@ export interface Filter<T> {
   hasRequiredError(): boolean;
   /**The number of selected options exceeded the allowed limit of selected options? */
   hasLimitError(): boolean;
+  /**The number of allowed selected options. */
+  limit?: number;
 }
 
 export interface UseFilterArg<T> {
@@ -118,6 +120,7 @@ function useFilter<T>(arg: UseFilterArg<T>): Filter<T> {
     isSameState,
     hasRequiredError,
     hasLimitError,
+    limit,
   };
 }
 

--- a/src/components/Filters/useFilter.ts
+++ b/src/components/Filters/useFilter.ts
@@ -1,4 +1,4 @@
-import { Dispatch, useReducer, useState } from "react";
+import { Dispatch, useReducer, useState, SetStateAction } from "react";
 
 import { FILTER_CLEAR, FILTER_UPDATE } from "./actions";
 import createFilterReducer, { FilterState } from "./reducer";
@@ -20,7 +20,7 @@ export interface Filter<T> {
   /**Whether the filter's popup is open. */
   popupIsOpen: boolean;
   /**Toggle filter's UI popup open/close. */
-  setPopupIsOpen: Dispatch<boolean>;
+  setPopupIsOpen: Dispatch<SetStateAction<boolean>>;
   /**Returns the text representation of the filter's state. */
   getTextRep(): string;
   /**Return whether any of the filter's dataValue does not equal the default dataValue. */

--- a/src/components/Layout/HomeSearchBar/HomeSearchBar.tsx
+++ b/src/components/Layout/HomeSearchBar/HomeSearchBar.tsx
@@ -120,13 +120,19 @@ const HomeSearchBar: FC = () => {
   const [searchQuery, setSearchQuery] = useState<string>("");
   const [showFilters, setShowFilters] = useState<boolean>(false);
   const history = useHistory();
-  const dateRangeFilter = useFilter<string>("Date", { start: "", end: "" }, "", getDateText);
-  const searchTypeFilter = useFilter<boolean>(
-    "Search Type",
-    intialSearchTyperFilterState,
-    false,
-    getSearchTypeText
-  );
+  const dateRangeFilter = useFilter<string>({
+    name: "Date",
+    initialState: { start: "", end: "" },
+    defaultDataValue: "",
+    textRepFunction: getDateText,
+  });
+  const searchTypeFilter = useFilter<boolean>({
+    name: "Search Type",
+    initialState: intialSearchTyperFilterState,
+    defaultDataValue: false,
+    textRepFunction: getSearchTypeText,
+    isRequired: true,
+  });
 
   const onSearch: FormEventHandler<HTMLFormElement> = (event) => {
     event.preventDefault();
@@ -198,14 +204,14 @@ const HomeSearchBar: FC = () => {
               popupIsOpen={searchTypeFilter.popupIsOpen}
               setPopupIsOpen={searchTypeFilter.setPopupIsOpen}
               closeOnChange={false}
+              hasRequiredError={searchTypeFilter.hasRequiredError()}
             >
               <SelectTextFilterOptions
                 name={searchTypeFilter.name}
                 state={searchTypeFilter.state}
                 update={searchTypeFilter.update}
                 options={searchTypeOptions}
-                isRequired={true}
-                isActive={searchTypeFilter.isActive()}
+                hasRequiredError={searchTypeFilter.hasRequiredError()}
               />
             </FilterPopup>
           )}

--- a/src/components/Layout/HomeSearchBar/HomeSearchBar.tsx
+++ b/src/components/Layout/HomeSearchBar/HomeSearchBar.tsx
@@ -198,6 +198,7 @@ const HomeSearchBar: FC = () => {
         <div>
           {showFilters && (
             <FilterPopup
+              name={searchTypeFilter.name}
               clear={searchTypeFilter.clear}
               getTextRep={searchTypeFilter.getTextRep}
               isActive={searchTypeFilter.isActive}
@@ -211,7 +212,6 @@ const HomeSearchBar: FC = () => {
                 state={searchTypeFilter.state}
                 update={searchTypeFilter.update}
                 options={searchTypeOptions}
-                hasRequiredError={searchTypeFilter.hasRequiredError()}
               />
             </FilterPopup>
           )}
@@ -219,6 +219,7 @@ const HomeSearchBar: FC = () => {
         <div>
           {showFilters && (
             <FilterPopup
+              name={dateRangeFilter.name}
               clear={dateRangeFilter.clear}
               getTextRep={dateRangeFilter.getTextRep}
               isActive={dateRangeFilter.isActive}

--- a/src/components/Layout/HomeSearchBar/HomeSearchBar.tsx
+++ b/src/components/Layout/HomeSearchBar/HomeSearchBar.tsx
@@ -2,18 +2,19 @@ import React, { ChangeEventHandler, FC, FormEventHandler, useState } from "react
 import { useHistory } from "react-router-dom";
 import styled from "@emotion/styled";
 
+import { SEARCH_TYPE } from "../../../constants/ProjectConstants";
+
 import { FilterPopup } from "../../Filters/FilterPopup";
 import useFilter from "../../Filters/useFilter";
 import { FilterState } from "../../Filters/reducer";
 import { getDateText, SelectDateRange } from "../../Filters/SelectDateRange";
 import { getSelectedOptions, SelectTextFilterOptions } from "../../Filters/SelectTextFilterOptions";
-import { SEARCH_TYPE } from "../../../constants/ProjectConstants";
 import { screenWidths } from "../../../styles/mediaBreakpoints";
+import { strings } from "../../../assets/LocalizedStrings";
 
 import "@councildataproject/cdp-design/dist/colors.css";
 import "@mozilla-protocol/core/protocol/css/protocol.css";
 import "@mozilla-protocol/core/protocol/css/protocol-components.css";
-import { strings } from "../../../assets/LocalizedStrings";
 
 const EXAMPLE_TOPICS = [
   "minimum wage",
@@ -136,22 +137,17 @@ const HomeSearchBar: FC = () => {
 
   const onSearch: FormEventHandler<HTMLFormElement> = (event) => {
     event.preventDefault();
-    let queryParams = `?q=${searchQuery.trim().replace(/\s+/g, "+")}`;
-
+    const queryParams = `?q=${searchQuery.trim().replace(/\s+/g, "+")}`;
     const selectedSearchTypes = getSelectedOptions(searchTypeFilter.state);
-    if (selectedSearchTypes) {
-      queryParams += `&type=${selectedSearchTypes.join(",")}`;
-    }
-    if (dateRangeFilter.state.start) {
-      queryParams += `&start=${dateRangeFilter.state.start}`;
-    }
-    if (dateRangeFilter.state.end) {
-      queryParams += `&end=${dateRangeFilter.state.end}`;
-    }
     history.push({
       pathname: "/search",
       search: queryParams,
-      state: { query: searchQuery, types: selectedSearchTypes, ...dateRangeFilter.state },
+      state: {
+        query: searchQuery.trim(),
+        types: selectedSearchTypes,
+        committees: [],
+        dateRange: dateRangeFilter.state,
+      },
     });
   };
 

--- a/src/components/Shared/ChevronDownIcon.tsx
+++ b/src/components/Shared/ChevronDownIcon.tsx
@@ -1,0 +1,19 @@
+import React from "react";
+
+import "@councildataproject/cdp-design/dist/colors.css";
+
+const ChevronDownIcon = () => {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      className="h-6 w-6"
+      fill="none"
+      viewBox="0 0 24 24"
+      stroke="currentColor"
+    >
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+    </svg>
+  );
+};
+
+export default ChevronDownIcon;

--- a/src/containers/EventsContainer/EventsContainer.tsx
+++ b/src/containers/EventsContainer/EventsContainer.tsx
@@ -44,6 +44,8 @@ const Events = styled.div({
   },
 });
 
+const FETCH_EVENTS_BATCH_SIZE = 10;
+
 const EventsContainer: FC<EventsData> = ({ bodies, events }: EventsData) => {
   const { firebaseConfig } = useAppConfigContext();
 
@@ -73,11 +75,11 @@ const EventsContainer: FC<EventsData> = ({ bodies, events }: EventsData) => {
   const [state, dispatch] = useEventsPagination(
     firebaseConfig,
     {
-      eventsPerPage: 10,
+      batchSize: FETCH_EVENTS_BATCH_SIZE,
       events: events,
       fetchEvents: false,
       showMoreEvents: false,
-      hasMoreEvents: events.length === 10,
+      hasMoreEvents: events.length === FETCH_EVENTS_BATCH_SIZE,
       error: null,
     },
     getSelectedOptions(committeeFilter.state),

--- a/src/containers/EventsContainer/EventsContainer.tsx
+++ b/src/containers/EventsContainer/EventsContainer.tsx
@@ -50,6 +50,14 @@ interface ShowMoreEventsProps {
 }
 const ShowMoreEvents = styled.div<ShowMoreEventsProps>((props) => ({
   visibility: props.isVisible ? "visible" : "hidden",
+  "& > button": {
+    width: "100%",
+  },
+  [`@media (min-width:${screenWidths.tablet})`]: {
+    "& > button": {
+      width: "auto",
+    },
+  },
 }));
 
 const FETCH_EVENTS_BATCH_SIZE = 10;
@@ -163,7 +171,7 @@ const EventsContainer: FC<EventsData> = ({ bodies, events }: EventsData) => {
       <ShowMoreEvents isVisible={state.hasMoreEvents && !state.fetchEvents}>
         <button className="mzp-c-button mzp-t-secondary mzp-t-lg" onClick={handleShowMoreEvents}>
           <span>Show more events</span>
-          <Loader inline active={state.showMoreEvents} size="tiny" style={{ marginLeft: 8 }} />
+          <Loader inline active={state.showMoreEvents} size="tiny" style={{ marginLeft: 16 }} />
         </button>
       </ShowMoreEvents>
     </Container>

--- a/src/containers/EventsContainer/EventsContainer.tsx
+++ b/src/containers/EventsContainer/EventsContainer.tsx
@@ -18,6 +18,7 @@ import {
 import useEventsPagination from "./useEventsPagination";
 import { EventsData } from "./types";
 
+import { strings } from "../../assets/LocalizedStrings";
 import colors from "../../styles/colors";
 import { fontSizes } from "../../styles/fonts";
 import { screenWidths } from "../../styles/mediaBreakpoints";
@@ -103,6 +104,7 @@ const EventsContainer: FC<EventsData> = ({ bodies, events }: EventsData) => {
 
   return (
     <Container>
+      <h1 className="mzp-u-title-sm">{strings.events}</h1>
       <EventsFilter
         allBodies={bodies}
         filters={[committeeFilter, dateRangeFilter, sortFilter]}

--- a/src/containers/EventsContainer/EventsContainer.tsx
+++ b/src/containers/EventsContainer/EventsContainer.tsx
@@ -40,7 +40,7 @@ const Events = styled.div({
   [`@media (min-width:${screenWidths.tablet})`]: {
     justifyContent: "space-between",
     "& > div": {
-      width: "45%",
+      width: "35%",
     },
   },
 });

--- a/src/containers/EventsContainer/EventsContainer.tsx
+++ b/src/containers/EventsContainer/EventsContainer.tsx
@@ -44,7 +44,15 @@ const EventsContainer: FC<EventsData> = ({ bodies, events }) => {
   const { firebaseConfig } = useAppConfigContext();
 
   const dateRangeFilter = useFilter<string>("Date", { start: "", end: "" }, "", getDateText);
-  const committeeFilter = useFilter<boolean>("Committee", {}, false, getCheckboxText);
+  const committeeFilter = useFilter<boolean>(
+    "Committee",
+    bodies.reduce((obj, body) => {
+      obj[body.id as string] = false;
+      return obj;
+    }, {} as Record<string, boolean>),
+    false,
+    getCheckboxText
+  );
   const sortFilter = useFilter<string>(
     "Sort",
     { by: "event_datetime", order: ORDER_DIRECTION.desc, label: "Newest first" },

--- a/src/containers/EventsContainer/EventsContainer.tsx
+++ b/src/containers/EventsContainer/EventsContainer.tsx
@@ -1,6 +1,7 @@
 import React, { FC, useCallback } from "react";
 import styled from "@emotion/styled";
 import { Link } from "react-router-dom";
+import { Loader } from "semantic-ui-react";
 
 import { useAppConfigContext } from "../../app";
 import { ORDER_DIRECTION } from "../../networking/constants";
@@ -66,13 +67,12 @@ const EventsContainer: FC<EventsData> = ({ bodies, events }) => {
   const [state, dispatch] = useEventsPagination(
     firebaseConfig,
     {
-      fetchEvents: false,
+      eventsPerPage: 10,
       events: events,
+      fetchEvents: false,
       showMoreEvents: false,
       hasMoreEvents: events.length === 10,
-      isLoading: false,
       error: null,
-      eventsPerPage: 10,
     },
     getSelectedOptions(committeeFilter.state),
     dateRangeFilter.state,
@@ -104,42 +104,52 @@ const EventsContainer: FC<EventsData> = ({ bodies, events }) => {
         ]}
         handlePopupClose={handlePopupClose}
       />
-      {state.events.length === 0 && <p>No events found.</p>}
-      <Events>
-        {state.events.map((event, i) => {
-          return (
-            <div key={i}>
-              <Link
-                to={`/events/${event.id}`}
-                style={{
-                  textDecoration: "none",
-                  color: colors.black,
-                  fontSize: fontSizes.font_size_6,
-                }}
-              >
-                <MeetingCard
-                  staticImgSrc={event.staticThumbnailURL}
-                  hoverImgSrc={event.hoverThumbnailURL}
-                  imgAlt={""}
-                  meetingDate={
-                    event.event_datetime?.toLocaleDateString("en-US", {
-                      month: "long",
-                      day: "numeric",
-                      year: "numeric",
-                    }) as string
-                  }
-                  committee={event.body?.name as string}
-                  tags={event.keyGrams}
-                />
-              </Link>
-            </div>
-          );
-        })}
-      </Events>
-      {state.hasMoreEvents && (
+      {state.fetchEvents ? (
+        <Loader active inline="centered" size="massive" />
+      ) : (
+        <>
+          {state.events.length > 0 ? (
+            <Events>
+              {state.events.map((event, i) => {
+                return (
+                  <div key={i}>
+                    <Link
+                      to={`/events/${event.id}`}
+                      style={{
+                        textDecoration: "none",
+                        color: colors.black,
+                        fontSize: fontSizes.font_size_6,
+                      }}
+                    >
+                      <MeetingCard
+                        staticImgSrc={event.staticThumbnailURL}
+                        hoverImgSrc={event.hoverThumbnailURL}
+                        imgAlt={""}
+                        meetingDate={
+                          event.event_datetime?.toLocaleDateString("en-US", {
+                            month: "long",
+                            day: "numeric",
+                            year: "numeric",
+                          }) as string
+                        }
+                        committee={event.body?.name as string}
+                        tags={event.keyGrams}
+                      />
+                    </Link>
+                  </div>
+                );
+              })}
+            </Events>
+          ) : (
+            <p>No events found.</p>
+          )}
+        </>
+      )}
+      {state.hasMoreEvents && !state.fetchEvents && (
         <div>
           <button className="mzp-c-button mzp-t-secondary mzp-t-lg" onClick={handleShowMoreEvents}>
-            {state.isLoading ? "Loading..." : "Show more events"}
+            <span>Show more events</span>
+            <Loader inline active={state.showMoreEvents} size="tiny" style={{ marginLeft: 8 }} />
           </button>
         </div>
       )}

--- a/src/containers/EventsContainer/EventsContainer.tsx
+++ b/src/containers/EventsContainer/EventsContainer.tsx
@@ -99,8 +99,8 @@ const EventsContainer: FC<EventsData> = ({ bodies, events }) => {
         allBodies={bodies}
         filters={[committeeFilter, dateRangeFilter, sortFilter]}
         sortOptions={[
-          { by: "date", order: "desc", label: "Newest first" },
-          { by: "date", order: "asc", label: "Oldest first" },
+          { by: "event_datetime", order: "desc", label: "Newest first" },
+          { by: "event_datetime", order: "asc", label: "Oldest first" },
         ]}
         handlePopupClose={handlePopupClose}
       />

--- a/src/containers/EventsContainer/EventsContainer.tsx
+++ b/src/containers/EventsContainer/EventsContainer.tsx
@@ -1,6 +1,5 @@
 import React, { FC, useCallback } from "react";
 import styled from "@emotion/styled";
-import { Loader } from "semantic-ui-react";
 import { Link } from "react-router-dom";
 
 import { useAppConfigContext } from "../../app";
@@ -32,10 +31,14 @@ const Events = styled.div({
   display: "flex",
   flexDirection: "row",
   flexWrap: "wrap",
-  gap: 64,
+  rowGap: 64,
+  "& > div": {
+    width: "100%",
+  },
   [`@media (min-width:${screenWidths.tablet})`]: {
+    justifyContent: "space-between",
     "& > div": {
-      width: "40%",
+      width: "45%",
     },
   },
 });

--- a/src/containers/EventsContainer/EventsContainer.tsx
+++ b/src/containers/EventsContainer/EventsContainer.tsx
@@ -1,9 +1,17 @@
-import React, { FC, useCallback, useMemo } from "react";
+import React, {
+  FC,
+  useCallback,
+  useMemo,
+  useState,
+  ChangeEventHandler,
+  FormEventHandler,
+} from "react";
 import styled from "@emotion/styled";
-import { Link } from "react-router-dom";
+import { Link, useHistory } from "react-router-dom";
 import { Loader } from "semantic-ui-react";
 
 import { useAppConfigContext } from "../../app";
+import { SEARCH_TYPE } from "../../constants/ProjectConstants";
 import { ORDER_DIRECTION, OR_QUERY_LIMIT_NUM } from "../../networking/constants";
 
 import { MeetingCard } from "../../components/Cards/MeetingCard";
@@ -27,6 +35,17 @@ const Container = styled.div({
   display: "flex",
   flexDirection: "column",
   gap: 32,
+});
+
+const SearchContainer = styled.div({
+  display: "grid",
+  gap: 8,
+  gridTemplateColumns: "1fr",
+  justifyContent: "start",
+  alignItems: "start",
+  [`@media (min-width:${screenWidths.tablet})`]: {
+    gridTemplateColumns: "1fr auto",
+  },
 });
 
 const Events = styled.div({
@@ -162,9 +181,45 @@ const EventsContainer: FC<EventsData> = ({ bodies, events }: EventsData) => {
     }
   }, [state.fetchEvents, state.error, state.events]);
 
+  const history = useHistory();
+  const [searchQuery, setSearchQuery] = useState("");
+  const onSearchChange: ChangeEventHandler<HTMLInputElement> = (event) =>
+    setSearchQuery(event.target.value);
+  const onSearch: FormEventHandler<HTMLFormElement> = (event) => {
+    event.preventDefault();
+    const queryParams = `?q=${searchQuery.trim().replace(/\s+/g, "+")}`;
+
+    history.push({
+      pathname: "/search",
+      search: queryParams,
+      state: {
+        query: searchQuery.trim(),
+        types: [SEARCH_TYPE.MEETING],
+        committees: getSelectedOptions(committeeFilter.state),
+        dateRange: dateRangeFilter.state,
+      },
+    });
+  };
+
   return (
     <Container>
       <h1 className="mzp-u-title-sm">{strings.events}</h1>
+      <form className="mzp-c-form" role="search" onSubmit={onSearch} style={{ marginBottom: 0 }}>
+        <SearchContainer>
+          <input
+            type="search"
+            placeholder={strings.search_topic_placeholder}
+            required
+            aria-required
+            value={searchQuery}
+            onChange={onSearchChange}
+            style={{ marginBottom: 0 }}
+          />
+          <button className="mzp-c-button mzp-t-product" type="submit">
+            {strings.search}
+          </button>
+        </SearchContainer>
+      </form>
       <EventsFilter
         allBodies={bodies}
         filters={[committeeFilter, dateRangeFilter, sortFilter]}

--- a/src/containers/EventsContainer/EventsContainer.tsx
+++ b/src/containers/EventsContainer/EventsContainer.tsx
@@ -1,0 +1,110 @@
+import React, { FC, useCallback } from "react";
+import { Link } from "react-router-dom";
+import styled from "@emotion/styled";
+
+import { useAppConfigContext } from "../../app";
+
+import useEventsPagination from "./useEventsPagination";
+import useFilter from "../../components/Filters/useFilter";
+import { getDateText } from "../../components/Filters/SelectDateRange";
+import { getCheckboxText } from "../../components/Filters/SelectTextFilterOptions";
+import { getSortingText } from "../../components/Filters/SelectSorting";
+import { ORDER_DIRECTION } from "../../networking/constants";
+import getSelectedOptions from "../../components/Filters/SelectTextFilterOptions/getSelectedOptions";
+import { Loader } from "semantic-ui-react";
+import { MeetingCard } from "../../components/Cards/MeetingCard";
+
+import colors from "../../styles/colors";
+import { fontSizes } from "../../styles/fonts";
+
+import { EventsData } from "./types";
+
+const Events = styled.div({
+  display: "flex",
+  flexDirection: "row",
+  flexWrap: "wrap",
+  gap: 24,
+  "& > *": {
+    width: "50%",
+  },
+});
+
+const EventsContainer: FC<EventsData> = ({ bodies, events }) => {
+  const { firebaseConfig } = useAppConfigContext();
+
+  const dateRangeFilter = useFilter<string>("Date", { start: "", end: "" }, "", getDateText);
+  const committeeFilter = useFilter<boolean>("Committee", {}, false, getCheckboxText);
+  const sortFilter = useFilter<string>(
+    "Sort",
+    { by: "event_datetime", order: ORDER_DIRECTION.desc, label: "Newest first" },
+    "",
+    getSortingText
+  );
+
+  const [state, dispatch] = useEventsPagination(
+    firebaseConfig,
+    {
+      shouldFetchEvents: false,
+      events: events,
+      hasMoreEvents: events.length === 10,
+      isLoading: false,
+      error: null,
+      eventsPerPage: 10,
+    },
+    getSelectedOptions(committeeFilter.state),
+    dateRangeFilter.state,
+    sortFilter.state
+  );
+
+  const handlePopupClose = useCallback(() => {
+    dispatch({ type: "FETCH_EVENTS" });
+  }, [dispatch]);
+
+  const handleShowMoreEvents = useCallback(() => dispatch({ type: "SHOW_MORE" }), [dispatch]);
+
+  if (state.isLoading) {
+    return <Loader />;
+  }
+
+  if (state.error) {
+    return <div>{state.error.toString()}</div>;
+  }
+
+  return (
+    <>
+      <Events>
+        {state.events.map((event, i) => {
+          return (
+            <Link
+              key={i}
+              to={`/events/${event.id}`}
+              style={{
+                textDecoration: "none",
+                color: colors.black,
+                fontSize: fontSizes.font_size_6,
+              }}
+            >
+              <MeetingCard
+                staticImgSrc={event.staticThumbnailURL}
+                hoverImgSrc={event.hoverThumbnailURL}
+                imgAlt={""}
+                meetingDate={
+                  event.event_datetime?.toLocaleDateString("en-US", {
+                    month: "long",
+                    day: "numeric",
+                    year: "numeric",
+                  }) as string
+                }
+                committee={event.body?.name as string}
+                tags={event.keyGrams}
+              />
+            </Link>
+          );
+        })}
+        {state.hasMoreEvents && <button onClick={handleShowMoreEvents}>Show more</button>}
+      </Events>
+    </>
+  );
+};
+
+export default EventsContainer;

--- a/src/containers/EventsContainer/EventsContainer.tsx
+++ b/src/containers/EventsContainer/EventsContainer.tsx
@@ -105,7 +105,7 @@ const EventsContainer: FC<EventsData> = ({ bodies, events }) => {
         handlePopupClose={handlePopupClose}
       />
       {state.fetchEvents ? (
-        <Loader active inline="centered" size="massive" />
+        <Loader active size="massive" style={{ top: "40%" }} />
       ) : (
         <>
           {state.events.length > 0 ? (

--- a/src/containers/EventsContainer/EventsContainer.tsx
+++ b/src/containers/EventsContainer/EventsContainer.tsx
@@ -4,7 +4,7 @@ import { Link } from "react-router-dom";
 import { Loader } from "semantic-ui-react";
 
 import { useAppConfigContext } from "../../app";
-import { ORDER_DIRECTION } from "../../networking/constants";
+import { ORDER_DIRECTION, OR_QUERY_LIMIT_NUM } from "../../networking/constants";
 
 import { MeetingCard } from "../../components/Cards/MeetingCard";
 import useFilter from "../../components/Filters/useFilter";
@@ -61,7 +61,7 @@ const EventsContainer: FC<EventsData> = ({ bodies, events }: EventsData) => {
     }, {} as Record<string, boolean>),
     defaultDataValue: false,
     textRepFunction: getCheckboxText,
-    limit: 10,
+    limit: OR_QUERY_LIMIT_NUM,
   });
   const sortFilter = useFilter<string>({
     name: "Sort",

--- a/src/containers/EventsContainer/EventsContainer.tsx
+++ b/src/containers/EventsContainer/EventsContainer.tsx
@@ -45,6 +45,10 @@ const Events = styled.div({
   },
 });
 
+const FetchEventsMsg = styled.p({
+  fontSize: fontSizes.font_size_6,
+});
+
 interface ShowMoreEventsProps {
   isVisible: boolean;
 }
@@ -119,9 +123,9 @@ const EventsContainer: FC<EventsData> = ({ bodies, events }: EventsData) => {
     if (state.fetchEvents) {
       return <Loader active size="massive" style={{ top: "40%" }} />;
     } else if (state.error) {
-      return <p>{state.error.toString()}</p>;
+      return <FetchEventsMsg>{state.error.toString()}</FetchEventsMsg>;
     } else if (state.events.length === 0) {
-      return <p>No events found.</p>;
+      return <FetchEventsMsg>No events found.</FetchEventsMsg>;
     } else {
       return (
         <Events>

--- a/src/containers/EventsContainer/EventsContainer.tsx
+++ b/src/containers/EventsContainer/EventsContainer.tsx
@@ -44,25 +44,31 @@ const Events = styled.div({
   },
 });
 
-const EventsContainer: FC<EventsData> = ({ bodies, events }) => {
+const EventsContainer: FC<EventsData> = ({ bodies, events }: EventsData) => {
   const { firebaseConfig } = useAppConfigContext();
 
-  const dateRangeFilter = useFilter<string>("Date", { start: "", end: "" }, "", getDateText);
-  const committeeFilter = useFilter<boolean>(
-    "Committee",
-    bodies.reduce((obj, body) => {
+  const dateRangeFilter = useFilter<string>({
+    name: "Date",
+    initialState: { start: "", end: "" },
+    defaultDataValue: "",
+    textRepFunction: getDateText,
+  });
+  const committeeFilter = useFilter<boolean>({
+    name: "Committee",
+    initialState: bodies.reduce((obj, body) => {
       obj[body.id as string] = false;
       return obj;
     }, {} as Record<string, boolean>),
-    false,
-    getCheckboxText
-  );
-  const sortFilter = useFilter<string>(
-    "Sort",
-    { by: "event_datetime", order: ORDER_DIRECTION.desc, label: "Newest first" },
-    "",
-    getSortingText
-  );
+    defaultDataValue: false,
+    textRepFunction: getCheckboxText,
+    limit: 10,
+  });
+  const sortFilter = useFilter<string>({
+    name: "Sort",
+    initialState: { by: "event_datetime", order: ORDER_DIRECTION.desc, label: "Newest first" },
+    defaultDataValue: "",
+    textRepFunction: getSortingText,
+  });
 
   const [state, dispatch] = useEventsPagination(
     firebaseConfig,

--- a/src/containers/EventsContainer/EventsContainer.tsx
+++ b/src/containers/EventsContainer/EventsContainer.tsx
@@ -53,6 +53,9 @@ const ShowMoreEvents = styled.div<ShowMoreEventsProps>((props) => ({
   "& > button": {
     width: "100%",
   },
+  "& .ui.loader": {
+    marginLeft: 16,
+  },
   [`@media (min-width:${screenWidths.tablet})`]: {
     "& > button": {
       width: "auto",
@@ -171,7 +174,7 @@ const EventsContainer: FC<EventsData> = ({ bodies, events }: EventsData) => {
       <ShowMoreEvents isVisible={state.hasMoreEvents && !state.fetchEvents}>
         <button className="mzp-c-button mzp-t-secondary mzp-t-lg" onClick={handleShowMoreEvents}>
           <span>Show more events</span>
-          <Loader inline active={state.showMoreEvents} size="tiny" style={{ marginLeft: 16 }} />
+          <Loader inline active={state.showMoreEvents} size="tiny" />
         </button>
       </ShowMoreEvents>
     </Container>

--- a/src/containers/EventsContainer/index.ts
+++ b/src/containers/EventsContainer/index.ts
@@ -1,0 +1,1 @@
+export { default as EventsContainer } from "./EventsContainer";

--- a/src/containers/EventsContainer/types.ts
+++ b/src/containers/EventsContainer/types.ts
@@ -1,0 +1,7 @@
+import Body from "../../models/Body";
+import { RenderableEvent } from "../../networking/EventService";
+
+export interface EventsData {
+  bodies: Body[];
+  events: RenderableEvent[];
+}

--- a/src/containers/EventsContainer/useEventsPagination.ts
+++ b/src/containers/EventsContainer/useEventsPagination.ts
@@ -11,13 +11,15 @@ export type Action =
   | { type: "SUCCESS"; payload: RenderableEvent[] }
   //The payload is whether to fetch events with different filter parameters or fetch more events with same filter parameters.
   | { type: "FETCH_EVENTS"; payload: boolean };
+
 export interface State {
-  fetchEvents: boolean;
   eventsPerPage: number;
   events: RenderableEvent[];
+  //Is currently fetching events with different filter parameters?
+  fetchEvents: boolean;
+  //Is currently fetching more events with the same filter parameters?
   showMoreEvents: boolean;
   hasMoreEvents: boolean;
-  isLoading: boolean;
   error: Error | null;
 }
 
@@ -26,7 +28,6 @@ export function eventsPageReducer(state: State, action: Action): State {
     case "SUCCESS": {
       return {
         ...state,
-        isLoading: false,
         events: state.fetchEvents ? action.payload : [...state.events, ...action.payload],
         fetchEvents: false,
         showMoreEvents: false,
@@ -36,7 +37,6 @@ export function eventsPageReducer(state: State, action: Action): State {
     case "FAILURE": {
       return {
         ...state,
-        isLoading: false,
         error: action.payload,
         fetchEvents: false,
         showMoreEvents: false,
@@ -45,7 +45,6 @@ export function eventsPageReducer(state: State, action: Action): State {
     case "FETCH_EVENTS": {
       return {
         ...state,
-        isLoading: true,
         error: null,
         fetchEvents: action.payload,
         showMoreEvents: !action.payload,
@@ -111,6 +110,7 @@ export default function useEventsPagination(
       didCancel = true;
     };
   }, [
+    state.eventsPerPage,
     state.events,
     state.fetchEvents,
     state.showMoreEvents,

--- a/src/containers/EventsContainer/useEventsPagination.ts
+++ b/src/containers/EventsContainer/useEventsPagination.ts
@@ -7,12 +7,10 @@ import EventService, { RenderableEvent } from "../../networking/EventService";
 import { createError } from "../../utils/createError";
 
 export type Action =
-  | { type: "INIT" }
   | { type: "FAILURE"; payload: Error }
   | { type: "SUCCESS"; payload: RenderableEvent[] }
-  | { type: "SHOW_MORE" }
-  | { type: "FETCH_EVENTS" };
-
+  //The payload is whether to fetch events with different filter parameters or fetch more events with same filter parameters.
+  | { type: "FETCH_EVENTS"; payload: boolean };
 export interface State {
   fetchEvents: boolean;
   eventsPerPage: number;
@@ -25,13 +23,6 @@ export interface State {
 
 export function eventsPageReducer(state: State, action: Action): State {
   switch (action.type) {
-    case "INIT": {
-      return {
-        ...state,
-        isLoading: true,
-        error: null,
-      };
-    }
     case "SUCCESS": {
       return {
         ...state,
@@ -48,18 +39,16 @@ export function eventsPageReducer(state: State, action: Action): State {
         isLoading: false,
         error: action.payload,
         fetchEvents: false,
-      };
-    }
-    case "SHOW_MORE": {
-      return {
-        ...state,
-        showMoreEvents: true,
+        showMoreEvents: false,
       };
     }
     case "FETCH_EVENTS": {
       return {
         ...state,
-        fetchEvents: true,
+        isLoading: true,
+        error: null,
+        fetchEvents: action.payload,
+        showMoreEvents: !action.payload,
       };
     }
     default: {
@@ -129,6 +118,7 @@ export default function useEventsPagination(
     bodyIds,
     dateRange,
     sort,
+    dispatch,
   ]);
 
   return [state, dispatch];

--- a/src/containers/EventsContainer/useEventsPagination.ts
+++ b/src/containers/EventsContainer/useEventsPagination.ts
@@ -13,7 +13,7 @@ export type Action =
   | { type: "FETCH_EVENTS"; payload: boolean };
 
 export interface State {
-  eventsPerPage: number;
+  batchSize: number;
   events: RenderableEvent[];
   //Is currently fetching events with different filter parameters?
   fetchEvents: boolean;
@@ -31,7 +31,7 @@ export function eventsPageReducer(state: State, action: Action): State {
         events: state.fetchEvents ? action.payload : [...state.events, ...action.payload],
         fetchEvents: false,
         showMoreEvents: false,
-        hasMoreEvents: action.payload.length === state.eventsPerPage,
+        hasMoreEvents: action.payload.length === state.batchSize,
       };
     }
     case "FAILURE": {
@@ -72,7 +72,7 @@ export default function useEventsPagination(
       try {
         const eventService = new EventService(firebaseConfig);
         const events = await eventService.getEvents(
-          state.eventsPerPage,
+          state.batchSize,
           bodyIds,
           {
             start: dateRange.start ? new Date(dateRange.start) : undefined,
@@ -110,7 +110,7 @@ export default function useEventsPagination(
       didCancel = true;
     };
   }, [
-    state.eventsPerPage,
+    state.batchSize,
     state.events,
     state.fetchEvents,
     state.showMoreEvents,

--- a/src/containers/EventsContainer/useEventsPagination.ts
+++ b/src/containers/EventsContainer/useEventsPagination.ts
@@ -1,0 +1,125 @@
+import { useEffect, useReducer, Dispatch } from "react";
+
+import { FirebaseConfig } from "../../app/AppConfigContext";
+import { ORDER_DIRECTION } from "../../networking/constants";
+
+import EventService, { RenderableEvent } from "../../networking/EventService";
+
+import { createError } from "../../utils/createError";
+
+export type Action =
+  | { type: "INIT" }
+  | { type: "FAILURE"; payload: Error }
+  | { type: "SUCCESS"; payload: RenderableEvent[] }
+  | { type: "SHOW_MORE" }
+  | { type: "UPDATE_CURRENT_PAGE"; payload: number }
+  | { type: "FETCH_EVENTS" };
+
+export interface State {
+  shouldFetchEvents: boolean;
+  eventsPerPage: number;
+  events: RenderableEvent[];
+  hasMoreEvents: boolean;
+  isLoading: boolean;
+  error: Error | null;
+}
+
+export function eventsPageReducer(state: State, action: Action): State {
+  switch (action.type) {
+    case "INIT": {
+      return {
+        ...state,
+        isLoading: true,
+        error: null,
+      };
+    }
+    case "SUCCESS": {
+      return {
+        ...state,
+        isLoading: false,
+        events: [...state.events, ...action.payload],
+        shouldFetchEvents: false,
+        hasMoreEvents: action.payload.length === state.eventsPerPage,
+      };
+    }
+    case "FAILURE": {
+      return {
+        ...state,
+        isLoading: false,
+        error: action.payload,
+        shouldFetchEvents: false,
+      };
+    }
+    case "SHOW_MORE": {
+      return {
+        ...state,
+        shouldFetchEvents: true,
+      };
+    }
+    case "FETCH_EVENTS": {
+      return {
+        ...state,
+        shouldFetchEvents: true,
+      };
+    }
+    default: {
+      return state;
+    }
+  }
+}
+
+export default function useEventsPagination(
+  firebaseConfig: FirebaseConfig,
+  initialState: State,
+  bodyIds: string[],
+  dateRange: Record<string, string>,
+  sort: Record<string, string>
+): [State, Dispatch<Action>] {
+  const [state, dispatch] = useReducer(eventsPageReducer, initialState);
+
+  useEffect(() => {
+    let didCancel = false;
+
+    const fetchEvents = async () => {
+      try {
+        const eventService = new EventService(firebaseConfig);
+        const events = await eventService.getEvents(
+          state.eventsPerPage,
+          bodyIds,
+          {
+            start: dateRange.start ? new Date(dateRange.start) : undefined,
+            end: dateRange.end ? new Date(dateRange.end) : undefined,
+          },
+          {
+            by: sort.by,
+            order: sort.order as ORDER_DIRECTION,
+          },
+          state.events.length > 0 ? state.events[state.events.length - 1].event_datetime : undefined
+        );
+        const renderableEvents = await Promise.all(
+          events.map((event) => {
+            return eventService.getRenderableEvent(event);
+          })
+        );
+        if (!didCancel) {
+          dispatch({ type: "SUCCESS", payload: renderableEvents });
+        }
+      } catch (e) {
+        if (!didCancel) {
+          const error = createError(e);
+          dispatch({ type: "FAILURE", payload: error });
+        }
+      }
+    };
+
+    if (state.shouldFetchEvents) {
+      fetchEvents();
+    }
+
+    return () => {
+      didCancel = true;
+    };
+  }, [state.events, state.shouldFetchEvents, firebaseConfig, bodyIds, dateRange, sort]);
+
+  return [state, dispatch];
+}

--- a/src/containers/FetchDataContainer/FetchDataContainer.tsx
+++ b/src/containers/FetchDataContainer/FetchDataContainer.tsx
@@ -14,7 +14,7 @@ const FetchDataContainer: FC<FetchDataContainerProps> = ({
   error,
 }: FetchDataContainerProps) => {
   if (isLoading) {
-    return <Loader />;
+    return <Loader active size="massive" />;
   }
   if (error) {
     // Display the error for now.

--- a/src/containers/FetchDataContainer/FetchDataContainer.tsx
+++ b/src/containers/FetchDataContainer/FetchDataContainer.tsx
@@ -14,7 +14,7 @@ const FetchDataContainer: FC<FetchDataContainerProps> = ({
   error,
 }: FetchDataContainerProps) => {
   if (isLoading) {
-    return <Loader active size="massive" />;
+    return <Loader active size="massive" style={{ top: "40%" }} />;
   }
   if (error) {
     // Display the error for now.

--- a/src/networking/BodyService.ts
+++ b/src/networking/BodyService.ts
@@ -1,0 +1,20 @@
+import { orderBy } from "@firebase/firestore";
+
+import ModelService from "./ModelService";
+import { COLLECTION_NAME } from "./PopulationOptions";
+
+import Body from "../models/Body";
+import { FirebaseConfig } from "../app/AppConfigContext";
+
+export default class BodyService extends ModelService {
+  constructor(firebaseConfig: FirebaseConfig) {
+    super(COLLECTION_NAME.Body, firebaseConfig);
+  }
+
+  async getAllBodies(): Promise<Body[]> {
+    const networkQueryResponse = this.networkService.getDocuments(COLLECTION_NAME.Body, [
+      orderBy("name"),
+    ]);
+    return this.createModels(networkQueryResponse, Body, `getAllBodies()`);
+  }
+}

--- a/src/networking/EventService.ts
+++ b/src/networking/EventService.ts
@@ -20,7 +20,7 @@ import {
   PopulationOptions,
   REF_PROPERTY_NAME,
 } from "./PopulationOptions";
-import { ORDER_DIRECTION, WHERE_OPERATOR } from "./constants";
+import { ORDER_DIRECTION, OR_QUERY_LIMIT_NUM, WHERE_OPERATOR } from "./constants";
 
 import Event from "../models/Event";
 
@@ -64,7 +64,7 @@ export default class EventService extends ModelService {
   }
 
   async getEvents(
-    eventsPerPage: number,
+    batchSize: number,
     bodyIds: string[],
     dateRange: { start?: Date; end?: Date },
     sort: { by: string; order: ORDER_DIRECTION },
@@ -72,7 +72,7 @@ export default class EventService extends ModelService {
   ): Promise<Event[]> {
     if (bodyIds.length > 10) {
       // allow only <= 10 bodies filtering
-      return Promise.reject(new Error("Number of bodies exceeded 10."));
+      return Promise.reject(new Error(`Number of bodies exceeded ${OR_QUERY_LIMIT_NUM}.`));
     }
 
     const queryConstraints: QueryConstraint[] = [];
@@ -102,7 +102,7 @@ export default class EventService extends ModelService {
       queryConstraints.push(startAfter(startAfterDate));
     }
 
-    queryConstraints.push(limit(eventsPerPage));
+    queryConstraints.push(limit(batchSize));
 
     const networkResponse = this.networkService.getDocuments(
       COLLECTION_NAME.Event,

--- a/src/networking/EventService.ts
+++ b/src/networking/EventService.ts
@@ -1,3 +1,18 @@
+import {
+  QueryConstraint,
+  where,
+  Timestamp,
+  doc,
+  orderBy,
+  limit,
+  startAfter,
+} from "@firebase/firestore";
+import { getStorage, ref, getDownloadURL } from "@firebase/storage";
+
+import { FirebaseConfig } from "../app/AppConfigContext";
+
+import { NetworkService } from "./NetworkService";
+import IndexedEventGramService from "./IndexedEventGramService";
 import ModelService from "./ModelService";
 import {
   COLLECTION_NAME,
@@ -5,13 +20,24 @@ import {
   PopulationOptions,
   REF_PROPERTY_NAME,
 } from "./PopulationOptions";
+import { ORDER_DIRECTION, WHERE_OPERATOR } from "./constants";
 
 import Event from "../models/Event";
-import { FirebaseConfig } from "../app/AppConfigContext";
+
+import { createError } from "../utils/createError";
+
+export interface RenderableEvent extends Event {
+  keyGrams: string[];
+  staticThumbnailURL: string;
+  hoverThumbnailURL: string;
+}
 
 export default class EventService extends ModelService {
+  indexedEventGramService: IndexedEventGramService;
+
   constructor(firebaseConfig: FirebaseConfig) {
     super(COLLECTION_NAME.Event, firebaseConfig);
+    this.indexedEventGramService = new IndexedEventGramService(firebaseConfig);
   }
 
   async getEventById(eventId: string): Promise<Event> {
@@ -35,5 +61,94 @@ export default class EventService extends ModelService {
     );
 
     return this.createModel(networkResponse, Event, `getFullEventById(${eventId})`);
+  }
+
+  async getEvents(
+    eventsPerPage: number,
+    bodyIds: string[],
+    dateRange: { start?: Date; end?: Date },
+    sort: { by: string; order: ORDER_DIRECTION },
+    startAfterEventDate?: Date
+  ): Promise<Event[]> {
+    if (bodyIds.length > 10) {
+      // allow only <= 10 bodies filtering
+      return Promise.reject(new Error("Number of bodies exceeded 10."));
+    }
+
+    const queryConstraints: QueryConstraint[] = [];
+
+    if (bodyIds.length > 0) {
+      const bodyDocRefs = bodyIds.map((bodyId) =>
+        doc(NetworkService.getDb(), COLLECTION_NAME.Body, bodyId)
+      );
+      queryConstraints.push(where(REF_PROPERTY_NAME.EventBodyRef, WHERE_OPERATOR.in, bodyDocRefs));
+    }
+
+    if (dateRange.start) {
+      const start = Timestamp.fromDate(dateRange.start);
+      queryConstraints.push(where("event_datetime", WHERE_OPERATOR.gteq, start));
+    }
+    if (dateRange.end) {
+      const end = Timestamp.fromDate(dateRange.end);
+      queryConstraints.push(where("event_datetime", WHERE_OPERATOR.lteq, end));
+    }
+
+    queryConstraints.push(orderBy(sort.by, sort.order));
+
+    if (startAfterEventDate) {
+      const startAfterDate = Timestamp.fromDate(startAfterEventDate);
+      queryConstraints.push(startAfter(startAfterDate));
+    }
+
+    queryConstraints.push(limit(eventsPerPage));
+
+    const networkResponse = this.networkService.getDocuments(
+      COLLECTION_NAME.Event,
+      queryConstraints,
+      new PopulationOptions([
+        new Populate(COLLECTION_NAME.Body, REF_PROPERTY_NAME.EventBodyRef),
+        new Populate(COLLECTION_NAME.File, REF_PROPERTY_NAME.EventStaticThumbnailRef),
+        new Populate(COLLECTION_NAME.File, REF_PROPERTY_NAME.EventHoverThumbnailRef),
+      ])
+    );
+
+    return this.createModels(
+      networkResponse,
+      Event,
+      `getEvents([${bodyIds}], ${JSON.stringify(dateRange)}, ${JSON.stringify(sort)}, ${
+        startAfterEventDate?.toISOString
+      }})`
+    );
+  }
+
+  async getRenderableEvent(event: Event): Promise<RenderableEvent> {
+    try {
+      const eventKeyGrams = await this.indexedEventGramService.getKeyGramsForEvent(
+        `${COLLECTION_NAME.Event}/${event.id}`
+      );
+      // Unpack keygrams to get strings
+      const keyGrams = eventKeyGrams.reduce((list, gram) => {
+        if (gram.unstemmed_gram !== undefined) {
+          list.push(gram.unstemmed_gram);
+        }
+        return list;
+      }, [] as string[]);
+      // Get https storage URLs
+      const storage = getStorage();
+      const staticThumbnailPathRef = ref(storage, event.static_thumbnail?.uri);
+      const hoverThumbnailPathRef = ref(storage, event.hover_thumbnail?.uri);
+      const staticThumbnailURL = await getDownloadURL(staticThumbnailPathRef);
+      const hoverThumbnailURL = await getDownloadURL(hoverThumbnailPathRef);
+      return Promise.resolve({
+        ...event,
+        keyGrams,
+        staticThumbnailURL,
+        hoverThumbnailURL,
+      });
+    } catch (err) {
+      const error = createError(err);
+      error.message = `eventService_getRenderableEvent(${JSON.stringify(event)})_${error.message}`;
+      return Promise.reject(error);
+    }
   }
 }

--- a/src/networking/EventService.ts
+++ b/src/networking/EventService.ts
@@ -89,7 +89,9 @@ export default class EventService extends ModelService {
       queryConstraints.push(where("event_datetime", WHERE_OPERATOR.gteq, start));
     }
     if (dateRange.end) {
-      const end = Timestamp.fromDate(dateRange.end);
+      const endDate = new Date(dateRange.end);
+      endDate.setDate(endDate.getDate() + 1);
+      const end = Timestamp.fromDate(endDate);
       queryConstraints.push(where("event_datetime", WHERE_OPERATOR.lteq, end));
     }
 

--- a/src/networking/IndexedEventGramService.ts
+++ b/src/networking/IndexedEventGramService.ts
@@ -3,7 +3,7 @@ import { COLLECTION_NAME } from "./PopulationOptions";
 
 import IndexedEventGram from "../models/IndexedEventGram";
 import { where, limit, orderBy, doc } from "firebase/firestore";
-import { WHERE_OPERATOR } from "./constants";
+import { ORDER_DIRECTION, WHERE_OPERATOR } from "./constants";
 import { NetworkService } from "./NetworkService";
 import { FirebaseConfig } from "../app/AppConfigContext";
 
@@ -26,7 +26,7 @@ export default class IndexedEventGramService extends ModelService {
   async getKeyGramsForEvent(eventRef: string): Promise<IndexedEventGram[]> {
     const networkResponse = this.networkService.getDocuments(COLLECTION_NAME.IndexedEventGram, [
       where("event_ref", WHERE_OPERATOR.eq, doc(NetworkService.getDb(), eventRef)),
-      orderBy("value", "desc"),
+      orderBy("value", ORDER_DIRECTION.desc),
       limit(5),
     ]);
 

--- a/src/networking/constants.ts
+++ b/src/networking/constants.ts
@@ -15,3 +15,6 @@ export enum ORDER_DIRECTION {
   asc = "asc",
   desc = "desc",
 }
+
+// https://firebase.google.com/docs/firestore/query-data/queries#query_limitations
+export const OR_QUERY_LIMIT_NUM = 10;

--- a/src/pages/EventsPage/EventsPage.tsx
+++ b/src/pages/EventsPage/EventsPage.tsx
@@ -1,6 +1,7 @@
 import React, { FC, useEffect } from "react";
 
 import { useAppConfigContext } from "../../app";
+import useDocumentTitle from "../../hooks/useDocumentTitle";
 
 import BodyService from "../../networking/BodyService";
 import EventService from "../../networking/EventService";
@@ -15,8 +16,11 @@ import { EventsContainer } from "../../containers/EventsContainer";
 
 import { createError } from "../../utils/createError";
 
+import { strings } from "../../assets/LocalizedStrings";
+
 const EventsPage: FC = () => {
   const { firebaseConfig } = useAppConfigContext();
+  useDocumentTitle(strings.events);
 
   const { state: eventsDataState, dispatch: eventsDataDispatch } = useFetchData<EventsData>({
     isLoading: false,

--- a/src/pages/EventsPage/EventsPage.tsx
+++ b/src/pages/EventsPage/EventsPage.tsx
@@ -1,7 +1,81 @@
-import React, { FC } from "react";
+import React, { FC, useEffect } from "react";
+
+import { useAppConfigContext } from "../../app";
+
+import BodyService from "../../networking/BodyService";
+import EventService from "../../networking/EventService";
+import { ORDER_DIRECTION } from "../../networking/constants";
+
+import { EventsData } from "../../containers/EventsContainer/types";
+import useFetchData, {
+  FetchDataActionType,
+} from "../../containers/FetchDataContainer/useFetchData";
+import FetchDataContainer from "../../containers/FetchDataContainer/FetchDataContainer";
+import { EventsContainer } from "../../containers/EventsContainer";
+
+import { createError } from "../../utils/createError";
 
 const EventsPage: FC = () => {
-  return <div>TODO</div>;
+  const { firebaseConfig } = useAppConfigContext();
+
+  const { state: eventsDataState, dispatch: eventsDataDispatch } = useFetchData<EventsData>({
+    isLoading: false,
+  });
+
+  useEffect(() => {
+    let didCancel = false;
+    const eventService = new EventService(firebaseConfig);
+    const bodyService = new BodyService(firebaseConfig);
+
+    const fetchEventsData = async () => {
+      eventsDataDispatch({ type: FetchDataActionType.FETCH_INIT });
+
+      try {
+        const bodies = await bodyService.getAllBodies();
+        const events = await eventService.getEvents(
+          10,
+          [],
+          { start: undefined, end: undefined },
+          {
+            by: "event_datetime",
+            order: ORDER_DIRECTION.desc,
+          }
+        );
+        const renderableEvents = await Promise.all(
+          events.map((event) => {
+            return eventService.getRenderableEvent(event);
+          })
+        );
+
+        if (!didCancel) {
+          eventsDataDispatch({
+            type: FetchDataActionType.FETCH_SUCCESS,
+            payload: {
+              bodies,
+              events: renderableEvents,
+            },
+          });
+        }
+      } catch (err) {
+        if (!didCancel) {
+          const error = createError(err);
+          eventsDataDispatch({ type: FetchDataActionType.FETCH_FAILURE, payload: error });
+        }
+      }
+    };
+
+    fetchEventsData();
+
+    return () => {
+      didCancel = true;
+    };
+  }, [firebaseConfig]);
+
+  return (
+    <FetchDataContainer isLoading={eventsDataState.isLoading} error={eventsDataState.error}>
+      {eventsDataState.data && <EventsContainer {...eventsDataState.data} />}
+    </FetchDataContainer>
+  );
 };
 
 export default EventsPage;


### PR DESCRIPTION
### Link to Relevant Issue

WIP #57 (the `/events` page)

### Description of Changes

### Network layer
- Added bodyService to fetch all bodies
- Added getEvents to eventService to fetch events

### Events page and container
- I used the FetchDataContainer to initially fetch all bodies and a batch of events in the EventsPage, which are then provided as props to EventsContainer, where the events are displayed. And where filtering, sorting, and pagination are implemented.

- The pagination is sorta like an infinite scroll, where users would see the initial batch of events and they can click `Show more events` to show more events.

### Misc changes
- I modified the Comittee filter UI a bit. Users can only select up to 10 bodies/committees to keep the getEvents function simple. This is because [firestore query constraints](https://firebase.google.com/docs/firestore/query-data/queries#query_limitations) only allows up to 10 equality in an `OR` query.

- Changed the trigger buttons of the filters, the clear and save buttons to actual buttons using Mozilla protocol styling.

### Link to Forked Storybook Site

I didn't write any stories for this PR.

To verify the changes:

1. npm run start
2. change the projecteId in index-react.tsx to `cdp-seattle-staging-dbengvtn`

https://user-images.githubusercontent.com/37560480/141205873-186d0374-b163-4a56-8490-ba513b0f05fe.png

