### PR TITLE
bugfixes/jump-to-sent-in-transcript

### DIFF
--- a/src/components/Details/TranscriptSearch/TranscriptItems.tsx
+++ b/src/components/Details/TranscriptSearch/TranscriptItems.tsx
@@ -65,7 +65,7 @@ const TranscriptItems: FC<TranscriptItemsProps> = ({
             searchQuery={searchQuery}
             speakerId={sentences[index].speaker_id}
             speakerPictureSrc={sentences[index].speaker_pictureSrc}
-            handleJumpToTranscript={handleJumpToTranscript(index)}
+            handleJumpToTranscript={handleJumpToTranscript(sentences[index].index)}
           />
         </div>
       </div>

--- a/src/components/Details/TranscriptSearch/TranscriptItems.tsx
+++ b/src/components/Details/TranscriptSearch/TranscriptItems.tsx
@@ -30,12 +30,7 @@ const TranscriptItems: FC<TranscriptItemsProps> = ({
   const handleJumpToVideoClip = (sessionIndex: number, startTime: number) => () =>
     jumpToVideoClip(sessionIndex, startTime);
   /**Creates a function that handles jumping to video clip at startTime and jumping to index-th sentence in full transcript */
-  const handleJumpToTranscript = (
-    sentenceIndex: number,
-    sessionIndex: number,
-    startTime: number
-  ) => () => {
-    jumpToVideoClip(sessionIndex, startTime);
+  const handleJumpToTranscript = (sentenceIndex: number) => () => {
     jumpToTranscript(sentenceIndex);
   };
   // Stores the CellMeasurer's measurements of all transcript items
@@ -70,11 +65,7 @@ const TranscriptItems: FC<TranscriptItemsProps> = ({
             searchQuery={searchQuery}
             speakerId={sentences[index].speaker_id}
             speakerPictureSrc={sentences[index].speaker_pictureSrc}
-            handleJumpToTranscript={handleJumpToTranscript(
-              index,
-              sentences[index].session_index,
-              sentences[index].start_time
-            )}
+            handleJumpToTranscript={handleJumpToTranscript(index)}
           />
         </div>
       </div>

--- a/src/components/Details/TranscriptSearch/TranscriptSearch.tsx
+++ b/src/components/Details/TranscriptSearch/TranscriptSearch.tsx
@@ -1,4 +1,4 @@
-import React, { ChangeEventHandler, FC, useState } from "react";
+import React, { ChangeEventHandler, FC, useState, useMemo } from "react";
 import styled from "@emotion/styled";
 import { strings } from "../../../assets/LocalizedStrings";
 import TranscriptItems from "./TranscriptItems";
@@ -69,7 +69,9 @@ const TranscriptSearch: FC<TranscriptSearchProps> = ({
   const onSearchChange: ChangeEventHandler<HTMLInputElement> = (event) =>
     setSearchTerm(event.target.value);
 
-  const visibleSentences = sentences.filter(({ text }) => isSubstring(text, searchTerm));
+  const visibleSentences = useMemo(() => {
+    return sentences.filter(({ text }) => isSubstring(text, searchTerm));
+  }, [sentences, searchTerm]);
 
   return (
     <Container>


### PR DESCRIPTION
### Link to Relevant Issue

This pull request resolves #109 

### Description of Changes

- Don't play the video at the timepoint when clicking on `jump to sentence in transcript`
- Fix the bug by navigating to the sentence's index relative to the entire list of sentences, instead of the index relative to the list of visible sentences.
- Memoized the calculation of the visible sentences. Just an optimization thing.