### PR TITLE
bugfixes/asset-modules-in-webpack-config

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,6 @@
     "eslint": "~6.6",
     "eslint-config-prettier": "~6.7",
     "eslint-plugin-react": "^7.19.0",
-    "file-loader": "^6.2.0",
     "gh-pages": "^3.1.0",
     "html-webpack-plugin": "^5.3.2",
     "husky": "~3.1",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -21,14 +21,23 @@ module.exports = {
         use: [{ loader: "babel-loader" }],
       },
       {
-        test: /\.(png|jpe?g|gif|svg|eot|ttf|woff|woff2)$/i,
-        type: "asset",
+        test: /\.(png|jpe?g|gif|svg)$/i,
+        type: "asset/resource",
+        generator: {
+          filename: "assets/img/[hash][ext]"
+        },
         use: [
-          "file-loader",
           {
             loader: "image-webpack-loader",
-          },
-        ],
+          }
+        ]
+      },
+      {
+        test: /\.(eot|ttf|woff|woff2)$/i,
+        type: "asset/resource",
+        generator: {
+          filename: "assets/fonts/[hash][ext]"
+        },
       },
       {
         test: /\.css/,
@@ -61,10 +70,7 @@ module.exports = {
     extensions: [".ts", ".tsx", ".js", ".jsx", "css"],
   },
   externals: {
-    "@emotion/styled": "@emotion/styled",
-    moment: "moment",
     react: "react",
-    "semantic-ui-react": "semantic-ui-react",
   },
   plugins: [new MiniCssExtractPlugin({ filename: "[name].css" })],
 };


### PR DESCRIPTION
### Link to Relevant Issue

This pull request (maybe) resolves #105. 

### Description of Changes

 The CSS classes that mention assets aren't being linked correctly. For example, the resulting style in index.css for the CDP icon was
```
.cdp-icon-black-bg-transparent-size-128 {
    content: url(data:image/png;base64,ZXhwb3J0IGRlZmF1bHQgX193ZWJwYWNrX3B1YmxpY19wYXRoX18gKyAiMjk0NmRiNmY5ZWZlYjQzZjIxMzZkNGIyMmI5MTE0NzkucG5nIjs=)
}
```
For some reason, that data URL wasn't working.

Since we are using webpack 5.x we might as well use their [asset modules](https://webpack.js.org/guides/asset-modules/).

I emitted the images to dist/assets/img and the fonts to dist/assets/fonts.

The resulting CSS is:
```
.cdp-icon-black-bg-transparent-size-128 {
    content: url(assets/img/2946db6f9efeb43f2136.png)
}
```

Note: Removed all the other externals, because now only react is required to be installed by the consumer of our library.
