### PR TITLE
feature/pass-query-to-event-page

### DIFF
--- a/src/components/Cards/MeetingCard/MeetingCard.stories.tsx
+++ b/src/components/Cards/MeetingCard/MeetingCard.stories.tsx
@@ -30,4 +30,5 @@ meetingSearchResult.args = {
   tags: ["bike", "adu", "accessories", "rental"],
   excerpt:
     "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce interdum, lorem eget vestibulum tincidunt, augue eros gravida lectus, ut efficitur neque nisi eu metus.",
+  gram: "ipsum",
 };

--- a/src/components/Cards/MeetingCard/MeetingCard.tsx
+++ b/src/components/Cards/MeetingCard/MeetingCard.tsx
@@ -1,5 +1,6 @@
-import React from "react";
+import React, { useMemo } from "react";
 import styled from "@emotion/styled";
+import Highlighter from "react-highlight-words";
 import { TAG_CONNECTOR } from "../../../constants/StyleConstants";
 import "@mozilla-protocol/core/protocol/css/protocol.css";
 import { strings } from "../../../assets/LocalizedStrings";
@@ -19,6 +20,10 @@ export type MeetingCardProps = {
   tags: string[];
   /** A context span if the event was found through searching */
   excerpt?: string;
+  /** The highest value gram of the context span */
+  gram?: string;
+  /** The query used to find this meeting */
+  query?: string;
 };
 
 const Meeting = styled.section({
@@ -41,8 +46,14 @@ const MeetingCard = ({
   committee,
   tags,
   excerpt,
+  gram,
+  query,
 }: MeetingCardProps) => {
   const tagString = tags.map((tag) => tag.toLowerCase()).join(TAG_CONNECTOR);
+
+  const searchWords = useMemo(() => {
+    return [gram || "", query || ""].filter((el) => el.length > 0);
+  }, [gram, query]);
 
   return (
     <Meeting className="mzp-c-card mzp-has-aspect-16-9">
@@ -55,15 +66,22 @@ const MeetingCard = ({
           <div className="mzp-c-card-tag">{strings.committee}</div>
           <h2 className="mzp-c-card-title">{meetingDate}</h2>
           <p className="mzp-c-card-desc">{committee}</p>
-          {excerpt ? (
+          {excerpt && (
             <p
               className="mzp-c-card-desc"
               style={{
                 fontStyle: "italic",
                 marginTop: "1rem",
               }}
-            >{`"${excerpt}"`}</p>
-          ) : null}
+            >
+              <Highlighter
+                autoEscape={true}
+                caseSensitive={false}
+                searchWords={searchWords}
+                textToHighlight={`"${excerpt}"`}
+              />
+            </p>
+          )}
           <p className="mzp-c-card-meta">{strings.keywords}</p>
           <p className="mzp-c-card-desc">{tagString}</p>
         </div>

--- a/src/components/Cards/MeetingCard/MeetingCard.tsx
+++ b/src/components/Cards/MeetingCard/MeetingCard.tsx
@@ -52,8 +52,12 @@ const MeetingCard = ({
   const tagString = tags.map((tag) => tag.toLowerCase()).join(TAG_CONNECTOR);
 
   const searchWords = useMemo(() => {
-    return [gram || "", query || ""].filter((el) => el.length > 0);
-  }, [gram, query]);
+    const words = [query || "", gram || ""].filter((el) => el.length > 0);
+    if (words.length === 0) {
+      return [];
+    }
+    return [new RegExp(`\\b(${words.join("|")})`, "g")];
+  }, [query, gram]);
 
   return (
     <Meeting className="mzp-c-card mzp-has-aspect-16-9">
@@ -75,7 +79,6 @@ const MeetingCard = ({
               }}
             >
               <Highlighter
-                autoEscape={true}
                 caseSensitive={false}
                 searchWords={searchWords}
                 textToHighlight={`"${excerpt}"`}

--- a/src/components/Cards/MeetingCard/MeetingCard.tsx
+++ b/src/components/Cards/MeetingCard/MeetingCard.tsx
@@ -1,9 +1,11 @@
 import React, { useMemo } from "react";
 import styled from "@emotion/styled";
 import Highlighter from "react-highlight-words";
+import { removeStopwords } from "stopword";
 import { TAG_CONNECTOR } from "../../../constants/StyleConstants";
 import "@mozilla-protocol/core/protocol/css/protocol.css";
 import { strings } from "../../../assets/LocalizedStrings";
+import cleanText from "../../../utils/cleanText";
 
 export type MeetingCardProps = {
   /** The static poster image src of the event */
@@ -52,11 +54,16 @@ const MeetingCard = ({
   const tagString = tags.map((tag) => tag.toLowerCase()).join(TAG_CONNECTOR);
 
   const searchWords = useMemo(() => {
-    const words = [query || "", gram || ""].filter((el) => el.length > 0);
-    if (words.length === 0) {
+    const cleanedQuery = cleanText(query || "");
+    // Phrases that should be highlighted in the excerpt
+    const phrases = removeStopwords(cleanedQuery.split(" "));
+    if (gram && gram.length > 0) {
+      phrases.push(gram);
+    }
+    if (phrases.length === 0) {
       return [];
     }
-    return [new RegExp(`\\b(${words.join("|")})`, "g")];
+    return [new RegExp(`\\b(${phrases.join("|")})`, "g")];
   }, [query, gram]);
 
   return (

--- a/src/components/Details/TranscriptItem/TranscriptItem.tsx
+++ b/src/components/Details/TranscriptItem/TranscriptItem.tsx
@@ -142,9 +142,9 @@ const TranscriptItem: FC<TranscriptItemProps> = ({
       return [];
     }
     const stemmedQuery = tokenizedQuery.map((token) => stem(token));
-    // highlight the token or the stem, but only if it's the start of the text or has a preceding whitespace
+    // highlight the token or the stem
     const regExps = tokenizedQuery.map(
-      (token, i) => new RegExp(`(^|\\s|-)(${token}|${stemmedQuery[i]})`, "g")
+      (token, i) => new RegExp(`\\b(${token}|${stemmedQuery[i]})`, "g")
     );
     if (searchQuery && searchQuery.trim().length > 0) {
       // highlight the original query too

--- a/src/components/Details/TranscriptSearch/TranscriptSearch.tsx
+++ b/src/components/Details/TranscriptSearch/TranscriptSearch.tsx
@@ -91,6 +91,9 @@ const TranscriptSearch: FC<TranscriptSearchProps> = ({
 
   //Update the visible sentences as the searched query changes
   const visibleSentences = useMemo(() => {
+    if (!searchedTerm.trim()) {
+      return sentences;
+    }
     const cleanedQuery = cleanText(searchedTerm);
     const tokenizedQuery = removeStopwords(cleanedQuery.split(" "));
     if (!cleanedQuery || tokenizedQuery.length === 0) {
@@ -105,9 +108,7 @@ const TranscriptSearch: FC<TranscriptSearchProps> = ({
     <Container>
       <TitleContainer>
         <div>{strings.search_transcript}</div>
-        {searchedTerm && (
-          <div>{strings.number_of_results.replace("{number}", `${visibleSentences.length}`)}</div>
-        )}
+        <div>{strings.number_of_results.replace("{number}", `${visibleSentences.length}`)}</div>
       </TitleContainer>
       <form className="mzp-c-form" role="search" onSubmit={onSearch}>
         <input

--- a/src/components/Details/TranscriptSearch/TranscriptSearch.tsx
+++ b/src/components/Details/TranscriptSearch/TranscriptSearch.tsx
@@ -1,13 +1,15 @@
-import React, { ChangeEventHandler, FC, useState, useMemo } from "react";
+import React, { ChangeEventHandler, FC, useState, useMemo, FormEventHandler } from "react";
 import styled from "@emotion/styled";
-import { strings } from "../../../assets/LocalizedStrings";
-import TranscriptItems from "./TranscriptItems";
+import { stem } from "stemr";
+import { removeStopwords } from "stopword";
 
+import TranscriptItems from "./TranscriptItems";
 import { SentenceWithSessionIndex } from "../../../containers/EventContainer/types";
 
+import { strings } from "../../../assets/LocalizedStrings";
 import { fontSizes } from "../../../styles/fonts";
 import { screenWidths } from "../../../styles/mediaBreakpoints";
-import isSubstring from "../../../utils/isSubstring";
+import cleanText from "../../../utils/cleanText";
 
 const Container = styled.div({
   display: "flex",
@@ -65,23 +67,49 @@ const TranscriptSearch: FC<TranscriptSearchProps> = ({
   jumpToVideoClip,
   jumpToTranscript,
 }: TranscriptSearchProps) => {
+  // Update the query in the search bar as the user types
   const [searchTerm, setSearchTerm] = useState<string>(searchQuery);
-  const onSearchChange: ChangeEventHandler<HTMLInputElement> = (event) =>
+  const onSearchChange: ChangeEventHandler<HTMLInputElement> = (event) => {
     setSearchTerm(event.target.value);
+  };
 
+  // The query after a search form submit
+  const [searchedTerm, setSearchedTerm] = useState(searchQuery);
+  const onSearch: FormEventHandler<HTMLFormElement> = (event) => {
+    event.preventDefault();
+    setSearchedTerm(searchTerm);
+  };
+
+  const stemmedSentences = useMemo(() => {
+    return sentences.map(({ text }) => {
+      const cleanedText = cleanText(text);
+      const tokens = removeStopwords(cleanedText.split(" "));
+      const stems = tokens.map((token) => stem(token).toLowerCase());
+      return new Set(stems);
+    });
+  }, [sentences]);
+
+  //Update the visible sentences as the searched query changes
   const visibleSentences = useMemo(() => {
-    return sentences.filter(({ text }) => isSubstring(text, searchTerm));
-  }, [sentences, searchTerm]);
+    const cleanedQuery = cleanText(searchedTerm);
+    const tokenizedQuery = removeStopwords(cleanedQuery.split(" "));
+    if (!cleanedQuery || tokenizedQuery.length === 0) {
+      // empty query or no valid tokens to search
+      return [];
+    }
+    const stemmedQuery = tokenizedQuery.map((token) => stem(token).toLowerCase());
+    return sentences.filter((_, i) => stemmedQuery.some((q) => stemmedSentences[i].has(q)));
+  }, [sentences, stemmedSentences, searchedTerm]);
 
   return (
     <Container>
       <TitleContainer>
         <div>{strings.search_transcript}</div>
-        {searchTerm && (
+        {searchedTerm && (
           <div>{strings.number_of_results.replace("{number}", `${visibleSentences.length}`)}</div>
         )}
       </TitleContainer>
-      <form className="mzp-c-form" role="search">
+      <form className="mzp-c-form" role="search" onSubmit={onSearch}>
         <input
           style={{ width: "100%" }}
           type="search"
@@ -92,7 +120,7 @@ const TranscriptSearch: FC<TranscriptSearchProps> = ({
       </form>
       <TranscriptContainer hasSearchResults={visibleSentences.length !== 0}>
         <TranscriptItems
-          searchQuery={searchTerm}
+          searchQuery={searchedTerm}
           sentences={visibleSentences}
           jumpToVideoClip={jumpToVideoClip}
           jumpToTranscript={jumpToTranscript}

--- a/src/containers/CardsContainer/CardsContainer.tsx
+++ b/src/containers/CardsContainer/CardsContainer.tsx
@@ -31,11 +31,16 @@ export interface CardsContainerProps {
 const CardsContainer: FC<CardsContainerProps> = ({ cards }: CardsContainerProps) => {
   return (
     <Container>
-      {cards.map(({ link, jsx }) => {
+      {cards.map(({ link, jsx, searchQuery }) => {
         return (
           <div key={link}>
             <Link
-              to={link}
+              to={{
+                pathname: link,
+                state: {
+                  query: searchQuery || "",
+                },
+              }}
               style={{
                 textDecoration: "none",
                 color: colors.black,

--- a/src/containers/CardsContainer/types.ts
+++ b/src/containers/CardsContainer/types.ts
@@ -1,6 +1,10 @@
 import { ReactNode } from "react";
 
 export interface Card {
+  //**The link pathname of the card */
   link: string;
+  /**The jsx element of the card */
   jsx: ReactNode;
+  /**The search query used to find the card */
+  searchQuery?: string;
 }

--- a/src/containers/SearchContainer/SearchContainer.tsx
+++ b/src/containers/SearchContainer/SearchContainer.tsx
@@ -112,6 +112,7 @@ const SearchContainer: FC<SearchContainerData> = ({ searchState }: SearchContain
             committee={renderableEvent.event.body?.name as string}
             tags={renderableEvent.keyGrams}
             excerpt={renderableEvent.selectedContextSpan}
+            //TODO: add the gram and queryRef.current
           />
         ),
       };

--- a/src/containers/SearchEventsContainer/SearchEventsContainer.tsx
+++ b/src/containers/SearchEventsContainer/SearchEventsContainer.tsx
@@ -169,6 +169,7 @@ const SearchEventsContainer: FC<SearchEventsContainerData> = ({
               excerpt={renderableEvent.selectedContextSpan}
             />
           ),
+          searchQuery: searchQueryRef.current,
         };
       });
       return (

--- a/src/containers/SearchEventsContainer/SearchEventsContainer.tsx
+++ b/src/containers/SearchEventsContainer/SearchEventsContainer.tsx
@@ -167,6 +167,8 @@ const SearchEventsContainer: FC<SearchEventsContainerData> = ({
               committee={renderableEvent.event.body?.name as string}
               tags={renderableEvent.keyGrams}
               excerpt={renderableEvent.selectedContextSpan}
+              gram={renderableEvent.selectedGram}
+              query={searchQueryRef.current}
             />
           ),
           searchQuery: searchQueryRef.current,

--- a/src/networking/EventSearchService.ts
+++ b/src/networking/EventSearchService.ts
@@ -24,6 +24,7 @@ class MatchingEvent {
   pureRelevance: number;
   datetimeWeightedRelevance: number;
   containedGrams: string[];
+  selectedGram: string;
   selectedContextSpan: string;
 
   constructor(
@@ -31,12 +32,14 @@ class MatchingEvent {
     pureRelevance: number,
     datetimeWeightedRelevance: number,
     containedGrams: string[],
+    selectedGram: string,
     selectedContextSpan: string
   ) {
     this.eventRef = `${COLLECTION_NAME.Event}/${eventId}`;
     this.pureRelevance = pureRelevance;
     this.datetimeWeightedRelevance = datetimeWeightedRelevance;
     this.containedGrams = containedGrams;
+    this.selectedGram = selectedGram;
     this.selectedContextSpan = selectedContextSpan;
   }
 }
@@ -51,6 +54,7 @@ export class RenderableEvent {
   pureRelevance: number;
   datetimeWeightedRelevance: number;
   containedGrams: string[];
+  selectedGram: string;
   selectedContextSpan: string;
   keyGrams: string[];
   staticThumbnailURL: string;
@@ -61,6 +65,7 @@ export class RenderableEvent {
     pureRelevance: number,
     datetimeWeightedRelevance: number,
     containedGrams: string[],
+    selectedGram: string,
     selectedContextSpan: string,
     keyGrams: string[],
     staticThumbnailURL: string,
@@ -70,6 +75,7 @@ export class RenderableEvent {
     this.pureRelevance = pureRelevance;
     this.datetimeWeightedRelevance = datetimeWeightedRelevance;
     this.containedGrams = containedGrams;
+    this.selectedGram = selectedGram;
     this.selectedContextSpan = selectedContextSpan;
     this.keyGrams = keyGrams;
     this.staticThumbnailURL = staticThumbnailURL;
@@ -185,10 +191,10 @@ export default class EventSearchService {
 
           // Unpack matchingGram to protect from undefined
           let selectedContextSpan = "";
-          if (matchingGramWithHighestValue && matchingGramWithHighestValue.context_span) {
-            selectedContextSpan = matchingGramWithHighestValue.context_span;
-          } else {
-            selectedContextSpan = "";
+          let selectedGram = "";
+          if (matchingGramWithHighestValue) {
+            selectedContextSpan = matchingGramWithHighestValue?.context_span || "";
+            selectedGram = matchingGramWithHighestValue?.unstemmed_gram || "";
           }
 
           // Get grams found in event from query
@@ -205,6 +211,7 @@ export default class EventSearchService {
               sumBy(matchingIndexedEventGrams, "value"),
               sumBy(matchingIndexedEventGrams, "datetime_weighted_value"),
               containedGrams,
+              selectedGram,
               selectedContextSpan
             )
           );
@@ -256,6 +263,7 @@ export default class EventSearchService {
           matchingEvent.pureRelevance,
           matchingEvent.datetimeWeightedRelevance,
           matchingEvent.containedGrams,
+          matchingEvent.selectedGram,
           matchingEvent.selectedContextSpan,
           keyUnstemmedGrams,
           staticThumbnailPathURL,

--- a/src/networking/EventSearchService.ts
+++ b/src/networking/EventSearchService.ts
@@ -12,6 +12,7 @@ import Event from "../models/Event";
 import { createError } from "../utils/createError";
 import { getStorage, ref, getDownloadURL } from "@firebase/storage";
 import { FirebaseConfig } from "../app/AppConfigContext";
+import cleanText from "../utils/cleanText";
 
 /**
  * The primary return of searchEvents.
@@ -104,23 +105,10 @@ export default class EventSearchService {
    * Returns as an array of string instead of string to pass into ngrams
    */
   cleanText(query: string): string[] {
-    // Replace new line and tab characters with a space
-    let cleanedQuery = query.replace(/[\t\n]+/g, " ");
-
-    // Replace common strings used by documents on backend
-    // Not _really_ needed here but a nice safety measure to match the alg
-    cleanedQuery = cleanedQuery.replace(/[\-\-]/, " ");
-
-    // Same as Python standard punctuation string
-    cleanedQuery = cleanedQuery.replace(/['!"#$%&\\'()\*+,\-\.\/:;<=>?@\[\\\]\^_`{|}~']/g, "");
-
-    // Remove extra spaces
-    cleanedQuery = cleanedQuery.replace(/\s{2,}/g, " ");
-
-    // Remove leading and trailing spaces
+    const cleanedQuery = cleanText(query);
     // Remove stopwords
     // Return as list of terms
-    return removeStopwords(cleanedQuery.trim().split(" "));
+    return removeStopwords(cleanedQuery.split(" "));
   }
 
   getStemmedGrams(query: string): string[] {

--- a/src/pages/EventPage/EventPage.tsx
+++ b/src/pages/EventPage/EventPage.tsx
@@ -1,6 +1,6 @@
-import React, { FC, useCallback } from "react";
+import React, { FC, useCallback, useMemo } from "react";
 
-import { useParams } from "react-router-dom";
+import { useParams, useLocation } from "react-router-dom";
 
 import { useAppConfigContext } from "../../app";
 import EventService from "../../networking/EventService";
@@ -22,6 +22,14 @@ const EventPage: FC = () => {
   const { id } = useParams<{ id: string }>();
   // Get the app config context
   const { firebaseConfig } = useAppConfigContext();
+  //Get the query
+  const location = useLocation<{ query: string }>();
+  const searchQuery = useMemo(() => {
+    if (location.state) {
+      return location.state.query;
+    }
+    return "";
+  }, [location.state]);
 
   const fetchEventData = useCallback(async () => {
     const eventService = new EventService(firebaseConfig);
@@ -115,7 +123,7 @@ const EventPage: FC = () => {
 
   return (
     <FetchDataContainer isLoading={eventDataState.isLoading} error={eventDataState.error}>
-      {eventDataState.data && <EventContainer {...eventDataState.data} />}
+      {eventDataState.data && <EventContainer {...eventDataState.data} searchQuery={searchQuery} />}
     </FetchDataContainer>
   );
 };

--- a/src/utils/cleanText.ts
+++ b/src/utils/cleanText.ts
@@ -1,0 +1,29 @@
+/**
+ * cleanText function is almost a mirror of the `clean_text` function from
+ * cdp-backend Python. Only major difference is there is no boolean parameter
+ * for indicating if we want to clean stopwords, this function is only currently
+ * used for searching and thus should always clean stopwords.
+ *
+ * Removes punctuation, line breaks, tabs, special character strings, stopwords,
+ * and any extra spaces in string (2+ spaces become 1 space).
+ *
+ */
+const cleanText = (text: string): string => {
+  // Replace new line and tab characters with a space
+  let cleanedText = text.replace(/[\t\n]+/g, " ");
+
+  // Replace common strings used by documents on backend
+  // Not _really_ needed here but a nice safety measure to match the alg
+  cleanedText = cleanedText.replace(/[\-\-]/g, " ");
+
+  // Same as Python standard punctuation string
+  cleanedText = cleanedText.replace(/['!"#$%&\\'()\*+,\-\.\/:;<=>?@\[\\\]\^_`{|}~']/g, "");
+
+  // Remove extra spaces
+  cleanedText = cleanedText.replace(/\s{2,}/g, " ");
+
+  // Remove leading and trailing spaces
+  return cleanedText.trim();
+};
+
+export default cleanText;


### PR DESCRIPTION
### Link to Relevant Issue

This pull request resolves #123 

### Description of Changes

- Highlight the gram with the highest value and/or user query in the exceprt portion of the event card.
- Pass the user query to the event page (after the user click on an event card from a search results page). And populate the user query in the search bar in "Search transcript".
- The "searching" is done through stem matching. A sentence is a search result if the stems of the sentence and the stems of the user query have at least one common element.
- The searching now doesn't happen instantly as the user types in the search bar, they have to press enter to get search results. 
- The highlighting appears on the search results and will highlight any stems or tokens of the user query.

### Link to Forked Storybook Site
https://tohuynh.github.io/cdp-frontend/?path=/story/library-cards-event--meeting-search-result (highlight even card)
