### PR TITLE
fix/odd-spacing-in-content-of-filter-popup

### DIFF
--- a/src/components/Filters/FilterPopup/FilterPopup.tsx
+++ b/src/components/Filters/FilterPopup/FilterPopup.tsx
@@ -32,7 +32,6 @@ TriggerButton.displayName = "TriggerButton";
 
 const StyledPopup = styled(Popup)({
   // limit the width of the popup
-  minWidth: "300px !important",
   maxWidth: "100% !important",
   boxShadow: "none !important",
   border: "2px solid #9595a2 !important",
@@ -61,6 +60,7 @@ const ButtonContainer = styled.div({
   display: "flex",
   justifyContent: "space-between",
   padding: ".833em 0 0",
+  minWidth: "256px",
 });
 ButtonContainer.displayName = "ButtonContainer";
 

--- a/src/components/Filters/SelectDateRange/SelectDateRange.tsx
+++ b/src/components/Filters/SelectDateRange/SelectDateRange.tsx
@@ -1,6 +1,7 @@
 import React, { ChangeEvent, FunctionComponent } from "react";
 import "@mozilla-protocol/core/protocol/css/protocol.css";
 import { FilterState } from "../reducer";
+import Form from "../Shared/Form";
 
 export interface SelectDateRangeProps {
   /**The date range state. */
@@ -21,7 +22,7 @@ const SelectDateRange: FunctionComponent<SelectDateRangeProps> = ({
   };
 
   return (
-    <form className="mzp-c-form">
+    <Form className="mzp-c-form">
       <div className="mzp-c-field">
         <label className="mzp-c-field-label" htmlFor="form-input-control-start-date">
           From
@@ -48,7 +49,7 @@ const SelectDateRange: FunctionComponent<SelectDateRangeProps> = ({
           onChange={onChange}
         ></input>
       </div>
-    </form>
+    </Form>
   );
 };
 

--- a/src/components/Filters/SelectSorting/SelectSorting.tsx
+++ b/src/components/Filters/SelectSorting/SelectSorting.tsx
@@ -2,6 +2,7 @@ import React, { FormEvent, FunctionComponent } from "react";
 import "@mozilla-protocol/core/protocol/css/protocol.css";
 import { FilterState } from "../reducer";
 import { SortOption } from "./getSortingText";
+import Form from "../Shared/Form";
 
 export interface SelectSortingProps {
   /**The list of sort options. */
@@ -35,8 +36,8 @@ const SelectSorting: FunctionComponent<SelectSortingProps> = ({
   };
 
   return (
-    <form className="mzp-c-form">
-      <fieldset style={{ marginBottom: "0" }}>
+    <Form className="mzp-c-form">
+      <fieldset className="mzp-c-field-set">
         <div className="mzp-c-choices">
           {sortOptions.map((sortOption) => (
             <div key={sortOption.label} className="mzp-c-choice">
@@ -58,7 +59,7 @@ const SelectSorting: FunctionComponent<SelectSortingProps> = ({
           ))}
         </div>
       </fieldset>
-    </form>
+    </Form>
   );
 };
 

--- a/src/components/Filters/SelectTextFilterOptions/SelectTextFilterOptions.tsx
+++ b/src/components/Filters/SelectTextFilterOptions/SelectTextFilterOptions.tsx
@@ -2,6 +2,8 @@ import React, { ChangeEvent, Dispatch, FunctionComponent, useMemo } from "react"
 
 import { FilterState } from "../reducer";
 
+import Form from "../Shared/Form";
+
 import isSubstring from "../../../utils/isSubstring";
 
 import "@mozilla-protocol/core/protocol/css/protocol.css";
@@ -71,7 +73,7 @@ const SelectTextFilterOptions: FunctionComponent<SelectTextFilterOptionsProps> =
   }, [options, optionQuery, setOptionQuery]);
 
   return (
-    <form className="mzp-c-form">
+    <Form className="mzp-c-form">
       {options.length > 5 && setOptionQuery && (
         <div className="mzp-c-field mzp-l-stretch">
           <label className="mzp-c-field-label" htmlFor="form-input-control-search-filter">
@@ -109,7 +111,7 @@ const SelectTextFilterOptions: FunctionComponent<SelectTextFilterOptionsProps> =
           ))}
         </div>
       </fieldset>
-    </form>
+    </Form>
   );
 };
 

--- a/src/components/Filters/Shared/Form.tsx
+++ b/src/components/Filters/Shared/Form.tsx
@@ -1,0 +1,11 @@
+import styled from "@emotion/styled";
+
+export default styled.form({
+  marginBottom: 0,
+  "& .mzp-c-field-set": {
+    padding: 0,
+  },
+  "& .mzp-c-choices": {
+    paddingBottom: 0,
+  },
+});

--- a/src/containers/SearchEventsContainer/SearchEventsContainer.tsx
+++ b/src/containers/SearchEventsContainer/SearchEventsContainer.tsx
@@ -6,7 +6,7 @@ import { Loader } from "semantic-ui-react";
 import { useAppConfigContext } from "../../app";
 import useDocumentTitle from "../../hooks/useDocumentTitle";
 import useSearchCards, { SearchCardsActionType } from "../../hooks/useSearchCards";
-import { ORDER_DIRECTION } from "../../networking/constants";
+import { ORDER_DIRECTION, OR_QUERY_LIMIT_NUM } from "../../networking/constants";
 import EventSearchService, { RenderableEvent } from "../../networking/EventSearchService";
 
 import { MeetingCard } from "../../components/Cards/MeetingCard";
@@ -53,6 +53,7 @@ const SearchEventsContainer: FC<SearchEventsContainerData> = ({
     initialState: searchEventsState.committees,
     defaultDataValue: false,
     textRepFunction: getCheckboxText,
+    limit: OR_QUERY_LIMIT_NUM,
   });
   const sortFilter = useFilter<string>({
     name: "Sort",


### PR DESCRIPTION
### Link to Relevant Issue

This pull request resolves some odd spacing in the sorting algo selection UI on the search results page.

### Description of Changes

The Mozilla protocol class for forms, fieldsets, and mzp-c-choices have margins and/or padding that creates extra whitespace below the list of sorting options. I created a styled component that sets the margin and/or padding to 0.

There is also extra whitespace to the right of the sorting options. I removed the min-width on the popup and let its content determine its width. Moved the min-width style to the button container so that there is some space between the buttons (in the other filters).

### Screenshots
![image](https://user-images.githubusercontent.com/37560480/144909887-09a6e0da-c89c-4de3-aea8-bafe0d52d533.png)
 

