### PR TITLE
Clean Styling Imports

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,6 +1,8 @@
 import React from "react";
 import { themes } from "@storybook/theming";
 import { StaticRouter } from 'react-router-dom';
+import "@councildataproject/cdp-design/dist/images.css";
+import "@mozilla-protocol/core/protocol/css/protocol.css";
 import "semantic-ui-css/semantic.min.css";
 
 export const decorators = [

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -2,7 +2,9 @@ import React from "react";
 import { themes } from "@storybook/theming";
 import { StaticRouter } from 'react-router-dom';
 import "@councildataproject/cdp-design/dist/images.css";
+import "@councildataproject/cdp-design/dist/colors.css";
 import "@mozilla-protocol/core/protocol/css/protocol.css";
+import "@mozilla-protocol/core/protocol/css/protocol-components.css";
 import "semantic-ui-css/semantic.min.css";
 
 export const decorators = [

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -20,7 +20,10 @@ import { SEARCH_TYPE } from "../pages/SearchPage/types";
 import { strings } from "../assets/LocalizedStrings";
 import { screenWidths } from "../styles/mediaBreakpoints";
 
+import "@councildataproject/cdp-design/dist/images.css";
+import "@councildataproject/cdp-design/dist/colors.css";
 import "@mozilla-protocol/core/protocol/css/protocol.css";
+import "@mozilla-protocol/core/protocol/css/protocol-components.css";
 import "semantic-ui-css/semantic.min.css";
 
 const FlexContainer = styled.div({

--- a/src/components/Cards/LegislationCard/LegislationCard.tsx
+++ b/src/components/Cards/LegislationCard/LegislationCard.tsx
@@ -7,8 +7,6 @@ import { TAG_CONNECTOR } from "../../../constants/StyleConstants";
 import { MATTER_STATUS_DECISION } from "../../../constants/ProjectConstants";
 import { strings } from "../../../assets/LocalizedStrings";
 
-import "@mozilla-protocol/core/protocol/css/protocol.css";
-
 const StatusIconContainer = styled.div({
   float: "right",
   marginRight: 8,

--- a/src/components/Cards/MeetingCard/MeetingCard.tsx
+++ b/src/components/Cards/MeetingCard/MeetingCard.tsx
@@ -3,7 +3,6 @@ import styled from "@emotion/styled";
 import Highlighter from "react-highlight-words";
 import { removeStopwords } from "stopword";
 import { TAG_CONNECTOR } from "../../../constants/StyleConstants";
-import "@mozilla-protocol/core/protocol/css/protocol.css";
 import { strings } from "../../../assets/LocalizedStrings";
 import cleanText from "../../../utils/cleanText";
 

--- a/src/components/Cards/PersonCard/PersonCard.tsx
+++ b/src/components/Cards/PersonCard/PersonCard.tsx
@@ -1,7 +1,6 @@
 import React, { FC } from "react";
 import styled from "@emotion/styled";
 import { strings } from "../../../assets/LocalizedStrings";
-import "@mozilla-protocol/core/protocol/css/protocol.css";
 
 const PersonStatus = styled.div({
   float: "right",

--- a/src/components/Details/MinutesItemsList/MinutesItemsList.tsx
+++ b/src/components/Details/MinutesItemsList/MinutesItemsList.tsx
@@ -1,7 +1,6 @@
 import React, { FC } from "react";
 import styled from "@emotion/styled";
 import { strings } from "../../../assets/LocalizedStrings";
-import "@mozilla-protocol/core/protocol/css/protocol.css";
 
 const DocumentsListOpen = styled.summary({
   width: "8.5rem",

--- a/src/components/Details/TranscriptItem/TranscriptItem.tsx
+++ b/src/components/Details/TranscriptItem/TranscriptItem.tsx
@@ -14,8 +14,6 @@ import PlayIcon from "../../Shared/PlayIcon";
 import { fontSizes } from "../../../styles/fonts";
 import cleanText from "../../../utils/cleanText";
 
-import "@mozilla-protocol/core/protocol/css/protocol.css";
-
 const Item = styled.div({
   display: "grid",
   gridTemplateColumns: "1fr",

--- a/src/components/Filters/FilterPopup/FilterPopup.tsx
+++ b/src/components/Filters/FilterPopup/FilterPopup.tsx
@@ -15,8 +15,6 @@ import ChevronDownIcon from "../../Shared/ChevronDownIcon";
 
 import { strings } from "../../../assets/LocalizedStrings";
 
-import "@mozilla-protocol/core/protocol/css/protocol.css";
-
 const TriggerButton = styled.button({
   display: "flex",
   justifyContent: "space-between",

--- a/src/components/Filters/SelectDateRange/SelectDateRange.tsx
+++ b/src/components/Filters/SelectDateRange/SelectDateRange.tsx
@@ -1,5 +1,4 @@
 import React, { ChangeEvent, FunctionComponent } from "react";
-import "@mozilla-protocol/core/protocol/css/protocol.css";
 import { FilterState } from "../reducer";
 
 export interface SelectDateRangeProps {

--- a/src/components/Filters/SelectSorting/SelectSorting.tsx
+++ b/src/components/Filters/SelectSorting/SelectSorting.tsx
@@ -1,5 +1,4 @@
 import React, { FormEvent, FunctionComponent } from "react";
-import "@mozilla-protocol/core/protocol/css/protocol.css";
 import { FilterState } from "../reducer";
 import { SortOption } from "./getSortingText";
 

--- a/src/components/Filters/SelectTextFilterOptions/SelectTextFilterOptions.tsx
+++ b/src/components/Filters/SelectTextFilterOptions/SelectTextFilterOptions.tsx
@@ -4,8 +4,6 @@ import { FilterState } from "../reducer";
 
 import isSubstring from "../../../utils/isSubstring";
 
-import "@mozilla-protocol/core/protocol/css/protocol-components.css";
-
 /**The type of of a filter option. */
 interface FilterOption {
   /**The name of the filter option. E.g. A Council Commitee's name is the id of the commitee. */

--- a/src/components/Filters/SelectTextFilterOptions/SelectTextFilterOptions.tsx
+++ b/src/components/Filters/SelectTextFilterOptions/SelectTextFilterOptions.tsx
@@ -4,7 +4,6 @@ import { FilterState } from "../reducer";
 
 import isSubstring from "../../../utils/isSubstring";
 
-import "@mozilla-protocol/core/protocol/css/protocol.css";
 import "@mozilla-protocol/core/protocol/css/protocol-components.css";
 
 /**The type of of a filter option. */

--- a/src/components/Layout/Footer/Footer.tsx
+++ b/src/components/Layout/Footer/Footer.tsx
@@ -1,6 +1,5 @@
 import React, { FC } from "react";
 import { strings } from "../../../assets/LocalizedStrings";
-import "@mozilla-protocol/core/protocol/css/protocol.css";
 
 interface Link {
   /*Displayed string represents the link*/

--- a/src/components/Layout/Header/Header.tsx
+++ b/src/components/Layout/Header/Header.tsx
@@ -6,8 +6,6 @@ import styled from "@emotion/styled";
 import { strings } from "../../../assets/LocalizedStrings";
 import { screenWidths } from "../../../styles/mediaBreakpoints";
 
-import "@councildataproject/cdp-design/dist/images.css";
-
 const CDPLogo = styled.div({
   float: "left",
   marginRight: "48px",

--- a/src/components/Layout/HomeSearchBar/HomeSearchBar.tsx
+++ b/src/components/Layout/HomeSearchBar/HomeSearchBar.tsx
@@ -13,10 +13,6 @@ import { FilterState } from "../../Filters/reducer";
 import { screenWidths } from "../../../styles/mediaBreakpoints";
 import { strings } from "../../../assets/LocalizedStrings";
 
-import "@councildataproject/cdp-design/dist/colors.css";
-import "@mozilla-protocol/core/protocol/css/protocol.css";
-import "@mozilla-protocol/core/protocol/css/protocol-components.css";
-
 const EXAMPLE_TOPICS = [
   "minimum wage",
   "police budget",

--- a/src/components/Layout/TabbedContainer/Tab.tsx
+++ b/src/components/Layout/TabbedContainer/Tab.tsx
@@ -1,5 +1,4 @@
 import React, { FunctionComponent } from "react";
-import "@mozilla-protocol/core/protocol/css/protocol.css";
 import styled from "@emotion/styled";
 import { STYLES } from "../../../constants/StyleConstants";
 

--- a/src/components/Layout/TabbedContainer/TabbedContainer.tsx
+++ b/src/components/Layout/TabbedContainer/TabbedContainer.tsx
@@ -1,7 +1,6 @@
 import React, { useState, FunctionComponent } from "react";
 import { Tab } from "./Tab";
 import styled from "@emotion/styled";
-import "@mozilla-protocol/core/protocol/css/protocol.css";
 
 const TabHeaderContainer = styled.div({
   display: "flex",

--- a/src/components/Shared/AbstainIcon.tsx
+++ b/src/components/Shared/AbstainIcon.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import "@councildataproject/cdp-design/dist/colors.css";
 
 const AbstainIcon = () => {
   return (

--- a/src/components/Shared/AdoptedIcon.tsx
+++ b/src/components/Shared/AdoptedIcon.tsx
@@ -1,7 +1,5 @@
 import React from "react";
 
-import "@councildataproject/cdp-design/dist/colors.css";
-
 const AdoptedIcon = () => {
   return (
     <svg

--- a/src/components/Shared/ChevronDownIcon.tsx
+++ b/src/components/Shared/ChevronDownIcon.tsx
@@ -1,7 +1,5 @@
 import React from "react";
 
-import "@councildataproject/cdp-design/dist/colors.css";
-
 const ChevronDownIcon = () => {
   return (
     <svg

--- a/src/components/Shared/DecisionResult.tsx
+++ b/src/components/Shared/DecisionResult.tsx
@@ -7,7 +7,6 @@ import useMediaQuery from "react-responsive";
 import { screenWidths } from "../../styles/mediaBreakpoints";
 import { MATTER_STATUS_DECISION } from "../../constants/ProjectConstants";
 import { VOTE_DECISION } from "../../constants/ProjectConstants";
-import "@mozilla-protocol/core/protocol/css/protocol.css";
 import { strings } from "../../assets/LocalizedStrings";
 
 interface DecisionResultProps {

--- a/src/components/Shared/InProgressIcon.tsx
+++ b/src/components/Shared/InProgressIcon.tsx
@@ -1,7 +1,5 @@
 import React from "react";
 
-import "@councildataproject/cdp-design/dist/colors.css";
-
 const InProgressIcon = () => {
   return (
     <svg

--- a/src/components/Shared/RejectedIcon.tsx
+++ b/src/components/Shared/RejectedIcon.tsx
@@ -1,7 +1,5 @@
 import React from "react";
 
-import "@councildataproject/cdp-design/dist/colors.css";
-
 const RejectedIcon = () => {
   return (
     <svg

--- a/src/components/Tables/EmptyRow/EmptyRow.tsx
+++ b/src/components/Tables/EmptyRow/EmptyRow.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import "@mozilla-protocol/core/protocol/css/protocol.css";
 
 type EmptyRowProps = {
   /** the index of this row */

--- a/src/components/Tables/MeetingVotesTable/MeetingVotesTable.tsx
+++ b/src/components/Tables/MeetingVotesTable/MeetingVotesTable.tsx
@@ -4,7 +4,6 @@ import { EmptyRow } from "../EmptyRow";
 import { ReactiveTable } from "../ReactiveTable";
 import { MeetingVote } from "../../Shared/Types/MeetingVote";
 import { strings } from "../../../assets/LocalizedStrings";
-import "@mozilla-protocol/core/protocol/css/protocol.css";
 
 export type MeetingVotesTableProps = {
   /** an array of Votes */

--- a/src/components/Tables/MeetingVotesTableRow/MeetingVotesTableRow.tsx
+++ b/src/components/Tables/MeetingVotesTableRow/MeetingVotesTableRow.tsx
@@ -8,7 +8,6 @@ import { ReactiveTableRow } from "../ReactiveTableRow";
 import useMediaQuery from "react-responsive";
 import { screenWidths } from "../../../styles/mediaBreakpoints";
 import { strings } from "../../../assets/LocalizedStrings";
-import "@mozilla-protocol/core/protocol/css/protocol.css";
 import { Link } from "react-router-dom";
 
 type MeetingVotesTableRowProps = {

--- a/src/components/Tables/ReactiveTable/ReactiveTable.tsx
+++ b/src/components/Tables/ReactiveTable/ReactiveTable.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import { ReactiveTableHeader } from "../ReactiveTableHeader";
 import { EmptyRow } from "../EmptyRow";
-import "@mozilla-protocol/core/protocol/css/protocol.css";
 
 type RowRenderFunction = (rowData: any, index: number) => JSX.Element;
 

--- a/src/components/Tables/ReactiveTableHeader/ReactiveTableHeader.tsx
+++ b/src/components/Tables/ReactiveTableHeader/ReactiveTableHeader.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import useMediaQuery from "react-responsive";
 import { screenWidths } from "../../../styles/mediaBreakpoints";
-import "@mozilla-protocol/core/protocol/css/protocol.css";
 
 type ReactiveTableHeaderProps = {
   /** column names */

--- a/src/components/Tables/ReactiveTableRow/ReactiveTableRow.tsx
+++ b/src/components/Tables/ReactiveTableRow/ReactiveTableRow.tsx
@@ -3,7 +3,6 @@ import { EmptyRow } from "../EmptyRow";
 import useMediaQuery from "react-responsive";
 import { screenWidths } from "../../../styles/mediaBreakpoints";
 import { STYLES } from "../../../constants/StyleConstants";
-import "@mozilla-protocol/core/protocol/css/protocol.css";
 
 type ReactiveTableRowProps = {
   /** the index of the row */

--- a/src/components/Tables/VotingTable/VotingTable.tsx
+++ b/src/components/Tables/VotingTable/VotingTable.tsx
@@ -3,7 +3,6 @@ import { VotingTableRow } from "../VotingTableRow";
 import { EmptyRow } from "../EmptyRow";
 import { strings } from "../../../assets/LocalizedStrings";
 import { ReactiveTable } from "../ReactiveTable";
-import "@mozilla-protocol/core/protocol/css/protocol.css";
 
 export type VotingTableProps = {
   /** the name of the legislator */

--- a/src/components/Tables/VotingTableRow/VotingTableRow.tsx
+++ b/src/components/Tables/VotingTableRow/VotingTableRow.tsx
@@ -3,7 +3,6 @@ import DecisionResult from "../../Shared/DecisionResult";
 import { MATTER_STATUS_DECISION } from "../../../constants/ProjectConstants";
 import { VOTE_DECISION } from "../../../constants/ProjectConstants";
 import { TAG_CONNECTOR } from "../../../constants/StyleConstants";
-import "@mozilla-protocol/core/protocol/css/protocol.css";
 import useMediaQuery from "react-responsive";
 import { screenWidths } from "../../../styles/mediaBreakpoints";
 import { ReactiveTableRow } from "../ReactiveTableRow";

--- a/src/containers/PersonContainer/PersonContainer.tsx
+++ b/src/containers/PersonContainer/PersonContainer.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import Person from "../../models/Person";
 import useDocumentTitle from "../../hooks/useDocumentTitle";
-import "@mozilla-protocol/core/protocol/css/protocol.css";
 
 export type PersonContainerProps = {
   /** The person's data */


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  ⚠️⚠️ Please do the following before submitting: ⚠️⚠️

  - Read the CONTRIBUTING.md guide and make sure you've followed all the steps given.
  - Ensure that the code is up-to-date with the `main` branch.
  - Provide or update documentation for any feature added by your pull request.
  - Provide relevant tests for your feature or bug fix.

  ❗️ Also: ❗️

  Please name your pull request {development-type}/{short-description}.
  For example: feature/read-tiff-files
-->

### Link to Relevant Issue

This pull request resolves [#115](https://github.com/CouncilDataProject/cdp-frontend/issues/115)

### Description of Changes

- Imported cdp design, Mozilla protocol and Semantic UI react styles in `.storybook/preview.js` and `src/app/App.tsx` 
- Removed cdp design, Mozilla protocol and Semantic UI react styles imports from multiple components

<!--
### Link to Forked Storybook Site

_If component changes (especially visual changes) are contained in this PR, we ask that you provide a link to a publicly viewable version of the Storybook docs site, so PR reviewers can see your changes without having to install and view your code locally._

_Please see `CONTRIBUTING.md` for directions on how this can be done._

-->
