### PR TITLE
fix/center-search-bar-in-homepage

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -41,6 +41,8 @@ const Main = styled.main({
   flex: 1,
   // Align center across the horizontal axis
   alignSelf: "center",
+  display: "flex",
+  flexDirection: "column",
   [`@media (min-width:${screenWidths.tablet})`]: {
     padding: "32px",
     maxWidth: "1280px",

--- a/src/pages/HomePage/HomePage.tsx
+++ b/src/pages/HomePage/HomePage.tsx
@@ -1,14 +1,27 @@
 import React, { FC } from "react";
 import styled from "@emotion/styled";
 
+import useDocumentTitle from "../../hooks/useDocumentTitle";
+
 import { HomeSearchBar } from "../../components/Layout/HomeSearchBar";
 
-import useDocumentTitle from "../../hooks/useDocumentTitle";
 import { strings } from "../../assets/LocalizedStrings";
+import { screenWidths } from "../../styles/mediaBreakpoints";
 
 const Container = styled.div({
-  display: "grid",
-  gridTemplateColumns: "1fr",
+  display: "flex",
+  flexDirection: "column",
+  justifyContent: "center",
+  alignItems: "center",
+  flex: 1,
+  "& > *": {
+    width: "100%",
+  },
+  [`@media (min-width:${screenWidths.tablet})`]: {
+    "& > *": {
+      width: "75%",
+    },
+  },
 });
 
 const HomePage: FC = () => {


### PR DESCRIPTION
### Link to Relevant Issue

This pull request resolves #130 

### Description of Changes

Just vertically centering the search bar on the home page.

### Screenshot

![image](https://user-images.githubusercontent.com/37560480/146460809-a38ba366-a77a-4734-a4cd-2ff55339c45e.png)
