### PR TITLE
fix/minutes-item-expansion

### DIFF
--- a/src/components/Details/MinutesItemsList/DocumentsList.tsx
+++ b/src/components/Details/MinutesItemsList/DocumentsList.tsx
@@ -12,11 +12,8 @@ const Summary = styled.summary({
   color: colors.dark_blue,
   display: "flex",
   alignItems: "center",
-  "&::before": {
+  "&::before, &::marker": {
     // remove mozilla protocol +/- icon
-    content: "none",
-  },
-  "&::marker": {
     // remove triangle marker
     content: "none",
   },

--- a/src/components/Details/MinutesItemsList/DocumentsList.tsx
+++ b/src/components/Details/MinutesItemsList/DocumentsList.tsx
@@ -1,0 +1,63 @@
+import React, { FC, useState } from "react";
+import styled from "@emotion/styled";
+
+import { Document } from "./types";
+import MinusIcon from "../../Shared/MinusIcon";
+import PlusIcon from "../../Shared/PlusIcon";
+
+import { strings } from "../../../assets/LocalizedStrings";
+import colors from "../../../styles/colors";
+
+const Summary = styled.summary({
+  color: colors.dark_blue,
+  display: "flex",
+  alignItems: "center",
+  "&::before": {
+    // remove mozilla protocol +/- icon
+    content: "none",
+  },
+  "&::marker": {
+    // remove triangle marker
+    content: "none",
+  },
+  "& svg": {
+    marginLeft: 4,
+    // limit the width and height of +/- icon
+    width: "1rem",
+    height: "1rem",
+  },
+});
+
+interface DocumentsListProps {
+  documents?: Document[];
+}
+
+const DocumentsList: FC<DocumentsListProps> = ({ documents }: DocumentsListProps) => {
+  const [isExpanded, setIsExpanded] = useState(false);
+  const onToggleIsExpanded = () => setIsExpanded((prev) => !prev);
+
+  if (!documents || documents.length === 0) {
+    return null;
+  }
+  return (
+    <details open={isExpanded} onToggle={onToggleIsExpanded}>
+      <Summary>
+        {strings.see_documents}
+        {isExpanded ? <MinusIcon /> : <PlusIcon />}
+      </Summary>
+      <ul>
+        {documents.map((doc) => {
+          return (
+            <li key={doc.label}>
+              <a href={doc.url} target="_blank" rel="noopener noreferrer">
+                {doc.label}
+              </a>
+            </li>
+          );
+        })}
+      </ul>
+    </details>
+  );
+};
+
+export default DocumentsList;

--- a/src/components/Details/MinutesItemsList/MinutesItemsList.stories.tsx
+++ b/src/components/Details/MinutesItemsList/MinutesItemsList.stories.tsx
@@ -14,11 +14,11 @@ export const minutesItemsList = Template.bind({});
 minutesItemsList.args = {
   minutesItems: [
     {
-      item: "Approval of the minutes",
+      name: "Approval of the minutes",
     },
     {
-      item: "Council briefing minutes (2019)",
-      docs: [
+      name: "Council briefing minutes (2019)",
+      documents: [
         {
           url: "http://google.com",
           label: "Meeting transcript",
@@ -30,14 +30,15 @@ minutesItemsList.args = {
       ],
     },
     {
-      item: "President's report",
+      name: "President's report",
     },
     {
-      item: "Preview of today's city council actions, council and regional committees",
+      name: "Preview of today's city council actions, council and regional committees",
     },
     {
-      item: "Inf 1579",
-      docs: [
+      name: "Inf 1579",
+      description: "Inf 1579 description",
+      documents: [
         {
           url: "http://google.com",
           label: "A document",
@@ -45,7 +46,7 @@ minutesItemsList.args = {
       ],
     },
     {
-      item: "Executive session on Pending, Potential, or Actual Litigation",
+      name: "Executive session on Pending, Potential, or Actual Litigation",
     },
   ],
 };

--- a/src/components/Details/MinutesItemsList/MinutesItemsList.tsx
+++ b/src/components/Details/MinutesItemsList/MinutesItemsList.tsx
@@ -1,55 +1,22 @@
 import React, { FC } from "react";
 import styled from "@emotion/styled";
-import { strings } from "../../../assets/LocalizedStrings";
 
-const DocumentsListOpen = styled.summary({
-  width: "8.5rem",
+import DocumentsList from "./DocumentsList";
+
+import { Item } from "./types";
+
+const ListItem = styled.li({
+  "& > div:first-of-type": {
+    // bold the minutes item's name
+    fontWeight: 600,
+  },
 });
-
-const DocumentsListParagraph = styled.p({
-  textDecoration: "underline",
-});
-
-interface Docs {
-  /*Document item label */
-  label: string;
-  /*Document item url */
-  url: string;
-}
-
-interface Items {
-  /*Minute item headline */
-  item: string;
-  /*Array of documents to be shown below*/
-  docs?: Docs[];
-}
 
 export interface MinutesItemsListProps {
   /**
    * List of minutes items headlines, each of which may have a list of associated documents
    */
-  minutesItems: Items[];
-}
-
-function returnDocList(docs: Docs[] | undefined) {
-  if (docs) {
-    return (
-      <section>
-        <details>
-          <DocumentsListOpen>
-            <DocumentsListParagraph>{strings.see_documents}</DocumentsListParagraph>
-          </DocumentsListOpen>
-          {docs.map((doc) => {
-            return (
-              <div key={doc.label}>
-                <a href={doc.url}>{doc.label}</a>
-              </div>
-            );
-          })}
-        </details>
-      </section>
-    );
-  }
+  minutesItems: Item[];
 }
 
 const MinutesItemsList: FC<MinutesItemsListProps> = ({ minutesItems }: MinutesItemsListProps) => {
@@ -57,10 +24,11 @@ const MinutesItemsList: FC<MinutesItemsListProps> = ({ minutesItems }: MinutesIt
     <ol className="mzp-u-list-styled">
       {minutesItems.map((elem) => {
         return (
-          <li key={elem.item}>
-            <div>{elem.item}</div>
-            <div>{returnDocList(elem.docs)}</div>
-          </li>
+          <ListItem key={elem.name}>
+            <div>{elem.name}</div>
+            {elem.description && <div>{elem.description}</div>}
+            <DocumentsList documents={elem.documents} />
+          </ListItem>
         );
       })}
     </ol>

--- a/src/components/Details/MinutesItemsList/types.ts
+++ b/src/components/Details/MinutesItemsList/types.ts
@@ -1,0 +1,13 @@
+import MinutesItem from "../../../models/MinutesItem";
+
+export interface Document {
+  /*Document item label */
+  label: string;
+  /*Document item url */
+  url: string;
+}
+
+export interface Item extends Pick<MinutesItem, "name" | "description"> {
+  /*Array of attachments for a given minutes item*/
+  documents?: Document[];
+}

--- a/src/components/Shared/MinusIcon.tsx
+++ b/src/components/Shared/MinusIcon.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+
+const MinusIcon = () => {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      className="h-6 w-6"
+      fill="none"
+      viewBox="0 0 24 24"
+      stroke="currentColor"
+    >
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M18 12H6" />
+    </svg>
+  );
+};
+
+export default MinusIcon;

--- a/src/components/Shared/PlusIcon.tsx
+++ b/src/components/Shared/PlusIcon.tsx
@@ -1,0 +1,22 @@
+import React from "react";
+
+const PlusIcon = () => {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      className="h-6 w-6"
+      fill="none"
+      viewBox="0 0 24 24"
+      stroke="currentColor"
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={2}
+        d="M12 6v6m0 0v6m0-6h6m-6 0H6"
+      />
+    </svg>
+  );
+};
+
+export default PlusIcon;

--- a/src/containers/EventContainer/EventInfoTabs.tsx
+++ b/src/containers/EventContainer/EventInfoTabs.tsx
@@ -41,8 +41,9 @@ const EventInfoTabs: FC<EventInfoTabsProps> = ({
   const minutesItems = eventMinutesItems.map(({ minutes_item }, i) => {
     const files = eventMinutesItemsFiles[i];
     return {
-      item: minutes_item?.name as string,
-      docs:
+      name: minutes_item?.name as string,
+      description: minutes_item?.description,
+      documents:
         files && files.length > 0
           ? files.map(({ name, uri }) => {
               return {


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  ⚠️⚠️ Please do the following before submitting: ⚠️⚠️

  - Read the CONTRIBUTING.md guide and make sure you've followed all the steps given.
  - Ensure that the code is up-to-date with the `main` branch.
  - Provide or update documentation for any feature added by your pull request.
  - Provide relevant tests for your feature or bug fix.

  ❗️ Also: ❗️

  Please name your pull request {development-type}/{short-description}.
  For example: feature/read-tiff-files
-->

### Link to Relevant Issue

This pull request resolves #126 

### Description of Changes

- Bold the minutes item's name to distinguish it from minutes item's description
- Add the minutes item's description
- "See documents" color is dark blue
- Remove the triangle marker (arrow right) from "See documents"
- Place the +/- icon immediately after "see documents" and make it all one line.
- Place the attachment links in `<ul>` to add indentation from the minutes item's name and description
- The attachment URL open in a new tab

### Screenshot

![image](https://user-images.githubusercontent.com/37560480/146492252-12ebfd04-f4a9-45e2-bd29-35c574773c02.png)

