### PR TITLE
feature/lazy-load-transcript-in-event-page

### DIFF
--- a/src/components/Details/TranscriptSearch/TranscriptSearch.stories.tsx
+++ b/src/components/Details/TranscriptSearch/TranscriptSearch.stories.tsx
@@ -55,7 +55,7 @@ manySentences.args = {
     session_index: 0,
     index: i,
     start_time: i,
-    text: `This is a sentence${i}.`,
+    text: `This is a sentence ${i}.`,
     speaker_name: "Lisa Herbold",
     speaker_id: "lisa-herbold",
     speaker_index: 0,

--- a/src/containers/EventContainer/EventContainer.stories.tsx
+++ b/src/containers/EventContainer/EventContainer.stories.tsx
@@ -51,46 +51,44 @@ event.args = {
       minutes_item: { name: "test" },
     },
     {
+      id: "test2",
       minutes_item: { name: "test2", description: "test desc", matter: { id: "matter-id" } },
       decision: MATTER_STATUS_DECISION.REJECTED,
+      files: [
+        {
+          name: "file name",
+          uri: "https://www.seattle.gov/images/Council/Members/Herbold/Herbold_225x225.jpg",
+        },
+      ],
     },
   ],
-  eventMinutesItemsFiles: [
-    [],
-    [
-      {
-        name: "file name",
-        uri: "https://www.seattle.gov/images/Council/Members/Herbold/Herbold_225x225.jpg",
-      },
-    ],
-  ],
   votes: [
-    [],
-    [
-      {
+    {
+      id: "1",
+      decision: VOTE_DECISION.APPROVE,
+      person: {
         id: "1",
-        decision: VOTE_DECISION.APPROVE,
-        person: {
-          id: "1",
-          name: "person name 1",
-        },
+        name: "person name 1",
       },
-      {
+      event_minutes_item_ref: "test2",
+    },
+    {
+      id: "2",
+      decision: VOTE_DECISION.REJECT,
+      person: {
         id: "2",
-        decision: VOTE_DECISION.REJECT,
-        person: {
-          id: "2",
-          name: "person name 2",
-        },
+        name: "person name 2",
       },
-      {
+      event_minutes_item_ref: "test2",
+    },
+    {
+      id: "3",
+      decision: VOTE_DECISION.REJECT,
+      person: {
         id: "3",
-        decision: VOTE_DECISION.REJECT,
-        person: {
-          id: "3",
-          name: "person name 3",
-        },
+        name: "person name 3",
       },
-    ],
+      event_minutes_item_ref: "test2",
+    },
   ],
 };

--- a/src/containers/EventContainer/EventInfoTabs.tsx
+++ b/src/containers/EventContainer/EventInfoTabs.tsx
@@ -1,9 +1,7 @@
-import React, { FC, Dispatch, SetStateAction, RefObject } from "react";
+import React, { FC, Dispatch, SetStateAction, RefObject, useMemo } from "react";
 
 import { TabProps } from "semantic-ui-react";
 
-import EventMinutesItem from "../../models/EventMinutesItem";
-import EventMinutesItemFile from "../../models/EventMinutesItemFile";
 import Vote from "../../models/Vote";
 
 import { TranscriptFull } from "../../components/Details/TranscriptFull";
@@ -11,18 +9,17 @@ import { TranscriptItemRef } from "../../components/Details/TranscriptItem/Trans
 import { MinutesItemsList } from "../../components/Details/MinutesItemsList";
 import { MeetingVotesTable } from "../../components/Tables/MeetingVotesTable";
 import ResponsiveTab from "../../components/Shared/ResponsiveTab";
+import { EventMinutesItemWithFiles, SentenceWithSessionIndex } from "./types";
 
-import { SentenceWithSessionIndex } from "./types";
 import { strings } from "../../assets/LocalizedStrings";
 
 interface EventInfoTabsProps {
   currentInfoTab: number;
   setCurrentInfoTab: Dispatch<SetStateAction<number>>;
-  sentences: SentenceWithSessionIndex[];
+  sentences?: SentenceWithSessionIndex[];
   transcriptItemsRefs: RefObject<TranscriptItemRef>[];
-  eventMinutesItems: EventMinutesItem[];
-  eventMinutesItemsFiles: EventMinutesItemFile[][];
-  votes: Vote[][];
+  eventMinutesItems: EventMinutesItemWithFiles[];
+  votes: Vote[];
   jumpToVideoClip(sessionIndex: number, startTime: number): void;
 }
 
@@ -32,78 +29,101 @@ const EventInfoTabs: FC<EventInfoTabsProps> = ({
   sentences,
   transcriptItemsRefs,
   eventMinutesItems,
-  eventMinutesItemsFiles,
   votes,
   jumpToVideoClip,
 }: EventInfoTabsProps) => {
   const onInfoTabChange = (_: any, data: TabProps) => setCurrentInfoTab(data.activeIndex as number);
 
-  const minutesItems = eventMinutesItems.map(({ minutes_item }, i) => {
-    const files = eventMinutesItemsFiles[i];
-    return {
-      name: minutes_item?.name as string,
-      description: minutes_item?.description,
-      documents:
-        files && files.length > 0
-          ? files.map(({ name, uri }) => {
-              return {
-                label: name as string,
-                url: uri as string,
-              };
-            })
-          : undefined,
-    };
-  });
+  const minutesItems = useMemo(() => {
+    return eventMinutesItems.map(({ minutes_item, files }) => {
+      return {
+        name: minutes_item?.name as string,
+        description: minutes_item?.description,
+        documents:
+          files && files.length > 0
+            ? files.map(({ name, uri }) => {
+                return {
+                  label: name as string,
+                  url: uri as string,
+                };
+              })
+            : undefined,
+      };
+    });
+  }, [eventMinutesItems]);
 
-  const votesPage: object[] = [];
-  eventMinutesItems.forEach(({ minutes_item, decision }, i) => {
-    const votesForEventMinutesItem = votes[i];
-    if (votesForEventMinutesItem && votesForEventMinutesItem.length > 0) {
-      votesPage.push({
-        matter: {
-          name: minutes_item?.name,
-          description: minutes_item?.description,
-          id: minutes_item?.matter?.id,
+  const votesByEventMinutesItemDict = useMemo(() => {
+    return votes.reduce((dict, vote) => {
+      if (!Object.keys(dict).includes(vote.event_minutes_item_ref as string)) {
+        dict[vote.event_minutes_item_ref as string] = [];
+      }
+      dict[vote.event_minutes_item_ref as string].push(vote);
+      return dict;
+    }, {} as Record<string, Vote[]>);
+  }, [votes]);
+
+  const votesByEventMinutesItem = useMemo(() => {
+    return eventMinutesItems.map((eventMinutesItem) => {
+      return votesByEventMinutesItemDict[eventMinutesItem.id as string] || [];
+    });
+  }, [votesByEventMinutesItemDict, eventMinutesItems]);
+
+  const votesPage = useMemo(() => {
+    const votesPage: object[] = [];
+    eventMinutesItems.forEach(({ minutes_item, decision }, i) => {
+      const votesForEventMinutesItem = votesByEventMinutesItem[i];
+      if (votesForEventMinutesItem && votesForEventMinutesItem.length > 0) {
+        votesPage.push({
+          matter: {
+            name: minutes_item?.name,
+            description: minutes_item?.description,
+            id: minutes_item?.matter?.id,
+          },
+          council_decision: decision,
+          votes: votesForEventMinutesItem.map(({ person, decision, id }) => {
+            return {
+              personId: person?.id,
+              name: person?.name,
+              decision: decision,
+              id: id,
+            };
+          }),
+        });
+      }
+    });
+    return votesPage;
+  }, [eventMinutesItems, votesByEventMinutesItem]);
+
+  const infoTabPanes = useMemo(() => {
+    return [
+      {
+        menuItem: strings.agenda,
+        pane: {
+          key: "agenda",
+          content: <MinutesItemsList minutesItems={minutesItems} />,
         },
-        council_decision: decision,
-        votes: votesForEventMinutesItem.map(({ person, decision, id }) => {
-          return {
-            personId: person?.id,
-            name: person?.name,
-            decision: decision,
-            id: id,
-          };
-        }),
-      });
-    }
-  });
-
-  const infoTabPanes = [
-    {
-      menuItem: strings.agenda,
-      pane: {
-        key: "agenda",
-        content: <MinutesItemsList minutesItems={minutesItems} />,
       },
-    },
-    {
-      menuItem: strings.transcript,
-      pane: {
-        key: "transcript",
-        content: (
-          <TranscriptFull
-            sentences={sentences}
-            transcriptItemsRefs={transcriptItemsRefs}
-            jumpToVideoClip={jumpToVideoClip}
-          />
-        ),
+      {
+        menuItem: strings.transcript,
+        pane: {
+          key: "transcript",
+          content: sentences ? (
+            <TranscriptFull
+              sentences={sentences}
+              transcriptItemsRefs={transcriptItemsRefs}
+              jumpToVideoClip={jumpToVideoClip}
+            />
+          ) : (
+            <div>Fetching transcript...</div>
+          ),
+        },
       },
-    },
-    {
-      menuItem: strings.votes,
-      pane: { key: "votes", content: <MeetingVotesTable votesPage={votesPage} /> },
-    },
-  ];
+      {
+        menuItem: strings.votes,
+        pane: { key: "votes", content: <MeetingVotesTable votesPage={votesPage} /> },
+      },
+    ];
+  }, [minutesItems, sentences, transcriptItemsRefs, jumpToVideoClip, votesPage]);
 
   return (
     <ResponsiveTab

--- a/src/containers/EventContainer/types.ts
+++ b/src/containers/EventContainer/types.ts
@@ -9,17 +9,19 @@ export interface SentenceWithSessionIndex extends Sentence {
   session_index: number;
 }
 
+export interface EventMinutesItemWithFiles extends EventMinutesItem {
+  files?: EventMinutesItemFile[];
+}
+
 export interface EventData {
   /**The event */
   event: Event;
   /** Session of the event */
   sessions: Session[];
   /** Sentences for the event */
-  sentences: SentenceWithSessionIndex[];
+  sentences?: SentenceWithSessionIndex[];
   /** Event minutes items of the event */
-  eventMinutesItems: EventMinutesItem[];
-  /** Event minutes items files */
-  eventMinutesItemsFiles: EventMinutesItemFile[][];
+  eventMinutesItems: EventMinutesItemWithFiles[];
   /** Votes for the event */
-  votes: Vote[][];
+  votes: Vote[];
 }

--- a/src/pages/EventPage/EventPage.tsx
+++ b/src/pages/EventPage/EventPage.tsx
@@ -1,6 +1,9 @@
-import React, { FC, useCallback, useMemo } from "react";
-
+import React, { FC, useCallback, useMemo, useEffect } from "react";
 import { useParams, useLocation } from "react-router-dom";
+
+import Event from "../../models/Event";
+import Session from "../../models/Session";
+import Vote from "../../models/Vote";
 
 import { useAppConfigContext } from "../../app";
 import EventService from "../../networking/EventService";
@@ -10,12 +13,22 @@ import EventMinutesItemService from "../../networking/EventMinutesItemService";
 import EventMinutesItemFileService from "../../networking/EventMinutesItemFileService";
 import VoteService from "../../networking/VoteService";
 import TranscriptJsonService from "../../networking/TranscriptJsonService";
-import Vote from "../../models/Vote";
 
 import { EventContainer } from "../../containers/EventContainer";
-import { SentenceWithSessionIndex, EventData } from "../../containers/EventContainer/types";
+import {
+  SentenceWithSessionIndex,
+  EventMinutesItemWithFiles,
+} from "../../containers/EventContainer/types";
 import { FetchDataContainer } from "../../containers/FetchDataContainer";
-import useFetchData from "../../containers/FetchDataContainer/useFetchData";
+import useFetchData, {
+  FetchDataActionType,
+} from "../../containers/FetchDataContainer/useFetchData";
+
+const initialFetchDataState = {
+  isLoading: false,
+  error: null,
+  hasFetchRequest: true,
+};
 
 const EventPage: FC = () => {
   // Get the id the the event, provided the route is `events/:id`
@@ -31,99 +44,170 @@ const EventPage: FC = () => {
     return "";
   }, [location.state]);
 
-  const fetchEventData = useCallback(async () => {
+  const fetchEvent = useCallback(async () => {
     const eventService = new EventService(firebaseConfig);
+    const event = await eventService.getEventById(id);
+    return Promise.resolve(event);
+  }, [firebaseConfig, id]);
+  const { state: eventDataState } = useFetchData<Event>({ ...initialFetchDataState }, fetchEvent);
+
+  const fetchSessions = useCallback(async () => {
     const sessionService = new SessionService(firebaseConfig);
-    const transcriptService = new TranscriptService(firebaseConfig);
+    const sessions = await sessionService.getSessionsByEventId(id);
+    return Promise.resolve(sessions);
+  }, [firebaseConfig, id]);
+  const { state: sessionsDataState } = useFetchData<Session[]>(
+    { ...initialFetchDataState },
+    fetchSessions
+  );
+
+  const fetchMinutesItemsWithFiles = useCallback(async () => {
     const eventMinutesItemService = new EventMinutesItemService(firebaseConfig);
     const eventMinutesItemFileService = new EventMinutesItemFileService(firebaseConfig);
-    const voteService = new VoteService(firebaseConfig);
-    const transcriptJsonService = new TranscriptJsonService(firebaseConfig);
-    // Get data from the event id
-    const eventPromise = eventService.getEventById(id);
-    const sessionsPromise = sessionService.getSessionsByEventId(id);
-    const eventMinutesItemsPromise = eventMinutesItemService.getEventMinutesItemsByEventId(id);
-    const votesPromise = voteService.getVotesByEventId(id);
-    const [event, sessions, eventMinutesItems, votes] = await Promise.all([
-      eventPromise,
-      sessionsPromise,
-      eventMinutesItemsPromise,
-      votesPromise,
-    ]);
-
-    // Get the event minutes items files from event minutes items
-    const eventMinutesItemsFilesPromise = Promise.all(
+    const eventMinutesItems = await eventMinutesItemService.getEventMinutesItemsByEventId(id);
+    const eventMinutesItemsFiles = await Promise.all(
       eventMinutesItems.map(({ id }) =>
         eventMinutesItemFileService.getEventMinutesItemFilesByEventMinutesItemId(id as string)
       )
     );
-    // Get the transcripts from the sessions
-    const transcriptsPromise = Promise.all(
-      sessions.map(({ id }) => transcriptService.getTranscriptBySessionId(id as string))
-    );
-    const [eventMinutesItemsFiles, transcripts] = await Promise.all([
-      eventMinutesItemsFilesPromise,
-      transcriptsPromise,
-    ]);
-
-    // Create transcript items from the transcripts
-    const transcriptJsons = await Promise.all(
-      transcripts.map((transcript) => {
-        return transcriptJsonService.download(transcript[0].file?.uri as string);
+    return Promise.resolve(
+      eventMinutesItems.map((eventMinutesItem, i) => {
+        return {
+          ...eventMinutesItem,
+          files: eventMinutesItemsFiles[i],
+        };
       })
     );
-    // Unpack sentences from all transcripts
-    const sentences: SentenceWithSessionIndex[] = [];
-    transcriptJsons.forEach((transcriptJson, sessionIndex) => {
-      transcriptJson?.sentences?.forEach((sentence) => {
-        sentences.push({
-          session_index: sessionIndex,
-          index: sentences.length,
-          start_time: sentence.start_time,
-          end_time: sentence.end_time,
-          text: sentence.text,
-          speaker_name: sentence.speaker_name,
-          speaker_index: sentence.speaker_index,
-          speaker_id: undefined,
-          speaker_pictureSrc: undefined,
-        } as SentenceWithSessionIndex);
-      });
-    });
-
-    // Create votes list for each event minutes item
-    const votesByEventMinutesItemDict = votes.reduce((dict, vote) => {
-      if (!Object.keys(dict).includes(vote.event_minutes_item_ref as string)) {
-        dict[vote.event_minutes_item_ref as string] = [];
-      }
-      dict[vote.event_minutes_item_ref as string].push(vote);
-      return dict;
-    }, {} as Record<string, Vote[]>);
-    const votesByEventMinutesItem = eventMinutesItems.map((eventMinutesItem) => {
-      return votesByEventMinutesItemDict[eventMinutesItem.id as string] || [];
-    });
-
-    return Promise.resolve({
-      event,
-      sessions,
-      sentences,
-      eventMinutesItems,
-      eventMinutesItemsFiles,
-      votes: votesByEventMinutesItem,
-    });
   }, [firebaseConfig, id]);
-
-  const { state: eventDataState } = useFetchData<EventData>(
-    {
-      isLoading: false,
-      error: null,
-      hasFetchRequest: true,
-    },
-    fetchEventData
+  const { state: eventMinutesItemsDataState } = useFetchData<EventMinutesItemWithFiles[]>(
+    { ...initialFetchDataState },
+    fetchMinutesItemsWithFiles
   );
 
+  const fetchVotes = useCallback(async () => {
+    const voteService = new VoteService(firebaseConfig);
+    const votes = await voteService.getVotesByEventId(id);
+    return Promise.resolve(votes);
+  }, [firebaseConfig, id]);
+  const { state: votesDataState } = useFetchData<Vote[]>({ ...initialFetchDataState }, fetchVotes);
+
+  const fetchSentences = useCallback(async () => {
+    const transcriptService = new TranscriptService(firebaseConfig);
+    const transcriptJsonService = new TranscriptJsonService(firebaseConfig);
+    if (sessionsDataState.data) {
+      // Get the transcripts from the sessions
+      const transcripts = await Promise.all(
+        sessionsDataState.data.map(({ id }) =>
+          transcriptService.getTranscriptBySessionId(id as string)
+        )
+      );
+      // Create transcript items from the transcripts
+      const transcriptJsons = await Promise.all(
+        transcripts.map((transcript) => {
+          return transcriptJsonService.download(transcript[0].file?.uri as string);
+        })
+      );
+      // Unpack sentences from all transcripts
+      const sentences: SentenceWithSessionIndex[] = [];
+      transcriptJsons.forEach((transcriptJson, sessionIndex) => {
+        transcriptJson?.sentences?.forEach((sentence) => {
+          sentences.push({
+            session_index: sessionIndex,
+            index: sentences.length,
+            start_time: sentence.start_time,
+            end_time: sentence.end_time,
+            text: sentence.text,
+            speaker_name: sentence.speaker_name,
+            speaker_index: sentence.speaker_index,
+            speaker_id: undefined,
+            speaker_pictureSrc: undefined,
+          } as SentenceWithSessionIndex);
+        });
+      });
+      return Promise.resolve(sentences);
+    }
+
+    return Promise.resolve([]);
+  }, [firebaseConfig, sessionsDataState.data]);
+  const { state: sentencesDataState, dispatch: sentencesDataDispatch } = useFetchData<
+    SentenceWithSessionIndex[]
+  >({ ...initialFetchDataState, hasFetchRequest: false }, fetchSentences);
+  useEffect(() => {
+    if (sessionsDataState.data) {
+      // fetch sentences after sessions are fetched
+      sentencesDataDispatch({ type: FetchDataActionType.FETCH });
+    }
+  }, [sessionsDataState.data, sentencesDataDispatch]);
+
+  const isFetchingEventData = useMemo(() => {
+    return (
+      eventDataState.isLoading ||
+      sessionsDataState.isLoading ||
+      eventMinutesItemsDataState.isLoading ||
+      votesDataState.isLoading
+    );
+  }, [
+    eventDataState.isLoading,
+    sessionsDataState.isLoading,
+    eventMinutesItemsDataState.isLoading,
+    votesDataState.isLoading,
+  ]);
+
+  const eventData = useMemo(() => {
+    if (
+      !eventDataState.data ||
+      !sessionsDataState.data ||
+      !eventMinutesItemsDataState.data ||
+      !votesDataState.data
+    ) {
+      // not all fetch requests has completed
+      return undefined;
+    }
+    return {
+      event: eventDataState.data,
+      sessions: sessionsDataState.data,
+      eventMinutesItems: eventMinutesItemsDataState.data,
+      votes: votesDataState.data,
+    };
+  }, [
+    eventDataState.data,
+    sessionsDataState.data,
+    eventMinutesItemsDataState.data,
+    votesDataState.data,
+  ]);
+
+  const fetchEventDataError = useMemo(() => {
+    const errorMsgs = [
+      eventDataState.error,
+      sessionsDataState.error,
+      eventMinutesItemsDataState.error,
+      votesDataState.error,
+      sentencesDataState.error,
+    ]
+      .map((error) => error?.message || "")
+      .filter((errorMsg) => errorMsg.length > 0);
+    if (errorMsgs.length > 0) {
+      // create one error from all the error msgs
+      return new Error(errorMsgs.join("\n"));
+    }
+    return null;
+  }, [
+    eventDataState.error,
+    sessionsDataState.error,
+    eventMinutesItemsDataState.error,
+    votesDataState.error,
+    sentencesDataState.error,
+  ]);
+
   return (
-    <FetchDataContainer isLoading={eventDataState.isLoading} error={eventDataState.error}>
-      {eventDataState.data && <EventContainer {...eventDataState.data} searchQuery={searchQuery} />}
+    <FetchDataContainer isLoading={isFetchingEventData} error={fetchEventDataError}>
+      {eventData && (
+        <EventContainer
+          {...eventData}
+          sentences={sentencesDataState.data}
+          searchQuery={searchQuery}
+        />
+      )}
     </FetchDataContainer>
   );
 };


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  ⚠️⚠️ Please do the following before submitting: ⚠️⚠️

  - Read the CONTRIBUTING.md guide and make sure you've followed all the steps given.
  - Ensure that the code is up-to-date with the `main` branch.
  - Provide or update documentation for any feature added by your pull request.
  - Provide relevant tests for your feature or bug fix.

  ❗️ Also: ❗️

  Please name your pull request {development-type}/{short-description}.
  For example: feature/read-tiff-files
-->

### Link to Relevant Issue

This pull request resolves #101 

### Description of Changes

The event page can load before the transcript JSON is retrieved. While the transcript is loading "Fetching transcript..." is shown in Search transcript component (where `N result(s)` is shown, to the right of `Search transcript`) and Full transcript component.

- Separate each call to the network layer(to get all the data for the event page) into its own `useFetchData`. The call to fetch transcript JSON runs when the call to fetch `sessions` is finished.
- Added some optimization with `useMemo` in `EventInfoTabs`
- Combined `eventMinutesItems` and `eventMinutesItemsFiles` into one prop.
