### PR TITLE
fix/person-and-seat-picture-src

### DIFF
--- a/src/components/Cards/PersonCard/PersonCard.tsx
+++ b/src/components/Cards/PersonCard/PersonCard.tsx
@@ -31,7 +31,7 @@ export interface PersonCardProps {
   /** The person's name */
   personName: string;
   /** The person's picture */
-  personPictureSrc: string;
+  personPictureSrc?: string;
   /** Is the person a current councilmember? */
   personIsActive: boolean;
   /** The seat's name */
@@ -65,13 +65,15 @@ const PersonCard: FC<PersonCardProps> = ({
     <section className="mzp-c-card mzp-c-card-medium mzp-has-aspect-16-9">
       <div className="mzp-c-card-block-link">
         <div className="mzp-c-card-media-wrapper">
-          <Img
-            className="mzp-c-card-image"
-            src={personPictureSrc}
-            width={seatHasPicture ? "40%" : "100%"}
-            left="0"
-            alt={personName}
-          />
+          {personPictureSrc && (
+            <Img
+              className="mzp-c-card-image"
+              src={personPictureSrc}
+              width={seatHasPicture ? "40%" : "100%"}
+              left="0"
+              alt={personName}
+            />
+          )}
           {seatHasPicture && (
             <Img
               className="mzp-c-card-image"

--- a/src/containers/PersonContainer/AvatarImage.tsx
+++ b/src/containers/PersonContainer/AvatarImage.tsx
@@ -9,8 +9,6 @@ const avatarGeneralStyle: React.CSSProperties = {
   top: "400px",
   left: "190px",
   borderRadius: 100,
-  backgroundColor: "white",
-  border: "1px black solid",
 };
 interface AvatarImageProps {
   /** The src of the avatar of the person being displayed */

--- a/src/containers/PersonContainer/AvatarImage.tsx
+++ b/src/containers/PersonContainer/AvatarImage.tsx
@@ -13,19 +13,19 @@ const avatarGeneralStyle: React.CSSProperties = {
   border: "1px black solid",
 };
 interface AvatarImageProps {
-  /** The uri of the avatar of the person being displayed */
-  personImageUri?: string;
+  /** The src of the avatar of the person being displayed */
+  personPictureSrc?: string;
   /** The name of the person being displayed (for alt) */
-  personName?: string;
+  personName: string;
 }
 
-const AvatarImage: FC<AvatarImageProps> = ({ personImageUri, personName }: AvatarImageProps) => {
-  if (personImageUri) {
+const AvatarImage: FC<AvatarImageProps> = ({ personPictureSrc, personName }: AvatarImageProps) => {
+  if (personPictureSrc) {
     return (
       <img
         style={avatarGeneralStyle}
         className="mzp-c-card-image"
-        src={personImageUri}
+        src={personPictureSrc}
         alt={`Picture of ${personName}`}
       />
     );

--- a/src/containers/PersonContainer/Biography.stories.tsx
+++ b/src/containers/PersonContainer/Biography.stories.tsx
@@ -22,6 +22,7 @@ const Template: Story<BiographyProps> = (args) => <Biography {...args} />;
 export const basicBio = Template.bind({});
 basicBio.args = {
   person: basicPerson,
-  roles: [ten_years_councilmember, expired_chair, recent_chair],
+  councilMemberRoles: [ten_years_councilmember],
+  roles: [expired_chair, recent_chair],
   mattersSponsored: [populatedMatterMatterSponsor, basicMatterSponsor],
 };

--- a/src/containers/PersonContainer/Biography.tsx
+++ b/src/containers/PersonContainer/Biography.tsx
@@ -8,15 +8,28 @@ import { writeBiography } from "./WriteBiography";
 interface BiographyProps {
   /** The person being displayed */
   person: Person;
+  /** The person's councilmember roles */
+  councilMemberRoles: Role[];
   /** The person's roles */
   roles: Role[];
   /** The legislation or matters sponsored by this person */
   mattersSponsored: MatterSponsor[];
 }
 
-const Biography: FC<BiographyProps> = ({ person, roles, mattersSponsored }: BiographyProps) => {
+const Biography: FC<BiographyProps> = ({
+  person,
+  councilMemberRoles,
+  roles,
+  mattersSponsored,
+}: BiographyProps) => {
   const { municipality } = useAppConfigContext();
-  const { bioText, introText } = writeBiography(person, roles, municipality.name, mattersSponsored);
+  const { bioText, introText } = writeBiography(
+    person,
+    councilMemberRoles,
+    roles,
+    municipality.name,
+    mattersSponsored
+  );
   const linkText = `Visit ${person.name}'s website`;
 
   return (

--- a/src/containers/PersonContainer/CoverImage.tsx
+++ b/src/containers/PersonContainer/CoverImage.tsx
@@ -1,7 +1,5 @@
 import React, { FC } from "react";
 import styled from "@emotion/styled";
-import Person from "../../models/Person";
-import Role from "../../models/Role";
 import { AvatarImage } from "./AvatarImage";
 
 import exampleCover1 from "../../assets/images/dave-hoefler-reduced-1.jpg";
@@ -25,38 +23,31 @@ const CoverImg = styled.img(() => ({
 }));
 
 interface CoverImageProps {
-  /** The person being displayed */
-  person: Person;
-  /** The current role of the person being displayed */
-  currentRole: Role;
+  personName: string;
+  personPictureSrc?: string;
+  seatPictureSrc?: string;
+  electoralArea?: string;
 }
 
-const CoverImage: FC<CoverImageProps> = ({ person, currentRole }: CoverImageProps) => {
-  if (currentRole.seat?.image?.uri) {
-    return (
-      <div>
-        <CoverImg
-          className="mzp-c-card-image"
-          src={currentRole.seat?.image?.uri}
-          alt={`${currentRole.seat?.electoral_area}`}
-        />
-        <AvatarImage personImageUri={person.picture?.uri} personName={person.name} />
-      </div>
-    );
-  } else {
-    const defaultCover =
-      EXAMPLE_COVER_VIEWS[Math.floor(Math.random() * EXAMPLE_COVER_VIEWS.length)];
-    return (
-      <div>
-        <CoverImg
-          className="mzp-c-card-image"
-          src={defaultCover}
-          alt={`Default Image, no Elector Seat Image Available`}
-        />
-        <AvatarImage personImageUri={person.picture?.uri} personName={person.name} />
-      </div>
-    );
-  }
+const CoverImage: FC<CoverImageProps> = ({
+  personName,
+  personPictureSrc,
+  seatPictureSrc,
+  electoralArea,
+}: CoverImageProps) => {
+  return (
+    <div>
+      <CoverImg
+        className="mzp-c-card-image"
+        src={
+          seatPictureSrc ||
+          EXAMPLE_COVER_VIEWS[Math.floor(Math.random() * EXAMPLE_COVER_VIEWS.length)]
+        }
+        alt={`${electoralArea || "Default Image, no Elector Seat Image Available"}`}
+      />
+      <AvatarImage personPictureSrc={personPictureSrc} personName={personName} />
+    </div>
+  );
 };
 
 export { CoverImage };

--- a/src/containers/PersonContainer/PersonContainer.stories.tsx
+++ b/src/containers/PersonContainer/PersonContainer.stories.tsx
@@ -11,6 +11,7 @@ import {
 } from "../../stories/model-mocks/matterSponsor";
 import { basicPerson } from "../../stories/model-mocks/person";
 import { vote } from "../../stories/model-mocks/vote";
+import { mockImageUrl } from "../../stories/model-mocks/imageUrl";
 import PersonContainer, { PersonContainerProps } from "./PersonContainer";
 
 export default {
@@ -24,14 +25,20 @@ export const personWithoutVotes = Template.bind({});
 personWithoutVotes.args = {
   person: basicPerson,
   votes: [],
-  roles: [ten_years_councilmember, expired_chair, recent_chair],
+  councilMemberRoles: [ten_years_councilmember],
+  roles: [expired_chair, recent_chair],
   mattersSponsored: [basicMatterSponsor, populatedMatterMatterSponsor],
+  personPictureSrc: mockImageUrl(400, 400, "Avatar Face"),
+  seatPictureSrc: mockImageUrl(1400, 800, "Electoral Seat"),
 };
 
 export const standardLayout = Template.bind({});
 standardLayout.args = {
   person: basicPerson,
-  roles: [ten_years_councilmember, expired_chair, recent_chair],
+  councilMemberRoles: [ten_years_councilmember],
+  roles: [expired_chair, recent_chair],
   mattersSponsored: [populatedMatterMatterSponsor],
   votes: [vote],
+  personPictureSrc: mockImageUrl(400, 400, "Avatar Face"),
+  seatPictureSrc: mockImageUrl(1400, 800, "Electoral Seat"),
 };

--- a/src/containers/PersonContainer/PersonContainer.tsx
+++ b/src/containers/PersonContainer/PersonContainer.tsx
@@ -58,7 +58,7 @@ const PersonContainer = ({
         />
       )}
       <br />
-      <VotingTable name={person.name} votesPage={votes as any} />
+      <VotingTable name={person.name} votesPage={votes} />
     </div>
   );
 };

--- a/src/containers/PersonContainer/PersonContainer.tsx
+++ b/src/containers/PersonContainer/PersonContainer.tsx
@@ -5,43 +5,60 @@ import { useMediaQuery } from "react-responsive";
 import { screenWidths } from "../../styles/mediaBreakpoints";
 import useDocumentTitle from "../../hooks/useDocumentTitle";
 import PersonFullView from "./PersonFullView";
-import { getMostRecentRole, filterRolesByTitle } from "../../models/util/RoleUtilities";
+import ordinalSuffix from "../../utils/ordinalSuffix";
 
 export interface PersonContainerProps extends PersonPageData {
   /** Any extra info */
   searchQuery?: string;
 }
 
-const PersonContainer = ({ person, votes, roles, mattersSponsored }: PersonContainerProps) => {
+const PersonContainer = ({
+  person,
+  votes,
+  roles,
+  councilMemberRoles,
+  mattersSponsored,
+  personPictureSrc,
+  seatPictureSrc,
+}: PersonContainerProps) => {
   const isMobile = useMediaQuery({ query: `(max-width: ${screenWidths.largeMobile})` });
-  const currentRole = getMostRecentRole(roles);
-  let rolesAsCurrentRole = 1;
-  if (currentRole.title) {
-    rolesAsCurrentRole = filterRolesByTitle(roles, currentRole.title).length;
-  }
+  const mostRecentCouncilMemberRole = councilMemberRoles[0];
 
   useDocumentTitle(person.name);
 
   return (
-    <div key={person.id}>
-      {isMobile && (
+    <div>
+      {isMobile ? (
         <PersonCard
           personName={person.name}
-          personPictureSrc={""}
-          personIsActive={person.is_active}
-          seatName={currentRole.seat?.name || "No name"}
-          seatElectoralArea={currentRole.seat?.electoral_area || "No Electoral Area"}
-          seatPictureSrc={currentRole.seat?.image?.uri}
-          chairedBodyNames={currentRole.title || ""}
-          tenureStatus={`${rolesAsCurrentRole}`}
-          billsSponsored={0}
+          personPictureSrc={personPictureSrc}
+          personIsActive={
+            mostRecentCouncilMemberRole.end_datetime
+              ? mostRecentCouncilMemberRole.end_datetime > new Date()
+              : true
+          }
+          seatName={mostRecentCouncilMemberRole.seat?.name || "No name"}
+          seatElectoralArea={
+            mostRecentCouncilMemberRole.seat?.electoral_area || "No Electoral Area"
+          }
+          seatPictureSrc={seatPictureSrc}
+          /**TODO fix list of chaired bodies */
+          chairedBodyNames={""}
+          tenureStatus={`${ordinalSuffix(councilMemberRoles.length)} term`}
+          billsSponsored={mattersSponsored.length}
+        />
+      ) : (
+        <PersonFullView
+          person={person}
+          personPictureSrc={personPictureSrc}
+          seatPictureSrc={seatPictureSrc}
+          councilMemberRoles={councilMemberRoles}
+          roles={roles}
+          mattersSponsored={mattersSponsored}
         />
       )}
-      {!isMobile && (
-        <PersonFullView person={person} roles={roles} mattersSponsored={mattersSponsored} />
-      )}
       <br />
-      {votes && <VotingTable name={person.name || "No Name Found"} votesPage={votes as any} />}
+      <VotingTable name={person.name} votesPage={votes as any} />
     </div>
   );
 };

--- a/src/containers/PersonContainer/PersonFullView.tsx
+++ b/src/containers/PersonContainer/PersonFullView.tsx
@@ -4,27 +4,37 @@ import Role from "../../models/Role";
 import MatterSponsor from "../../models/MatterSponsor";
 import { CoverImage } from "./CoverImage";
 import { Biography } from "./Biography";
-import { getMostRecentRole } from "../../models/util/RoleUtilities";
+
 interface PersonFullViewProps {
   /** The person being displayed */
   person: Person;
+  councilMemberRoles: Role[];
   roles: Role[];
   mattersSponsored: MatterSponsor[];
+  personPictureSrc?: string;
+  seatPictureSrc?: string;
 }
 
 const PersonFullView: FC<PersonFullViewProps> = ({
   person,
+  councilMemberRoles,
   roles,
   mattersSponsored,
+  personPictureSrc,
+  seatPictureSrc,
 }: PersonFullViewProps) => {
   const contactText = `Contact ${person.name}`;
-  const currentRole = getMostRecentRole(roles);
-
+  const mostRecentCouncilMemberRole = councilMemberRoles[0];
   return (
     <div>
       <h3>{person.name}</h3>
-      {currentRole.seat?.name && <h4>{currentRole.seat?.name}</h4>}
-      <CoverImage person={person} currentRole={currentRole} />
+      {mostRecentCouncilMemberRole.seat?.name && <h4>{mostRecentCouncilMemberRole.seat?.name}</h4>}
+      <CoverImage
+        personName={person.name}
+        personPictureSrc={personPictureSrc}
+        seatPictureSrc={seatPictureSrc}
+        electoralArea={mostRecentCouncilMemberRole.seat?.electoral_area}
+      />
       <div style={{ display: "flex", flexDirection: "row" }}>
         <div
           style={{
@@ -40,7 +50,12 @@ const PersonFullView: FC<PersonFullViewProps> = ({
           {person.email && <p className="mzp-c-card-desc">{person.email}</p>}
           {person.phone && <p className="mzp-c-card-desc">{person.phone}</p>}
         </div>
-        <Biography person={person} roles={roles} mattersSponsored={mattersSponsored} />
+        <Biography
+          person={person}
+          councilMemberRoles={councilMemberRoles}
+          roles={roles}
+          mattersSponsored={mattersSponsored}
+        />
       </div>
     </div>
   );

--- a/src/containers/PersonContainer/WriteBiography.tsx
+++ b/src/containers/PersonContainer/WriteBiography.tsx
@@ -2,15 +2,16 @@ import Person from "../../models/Person";
 import Role from "../../models/Role";
 import MatterSponsor from "../../models/MatterSponsor";
 import ordinalSuffix from "../../utils/ordinalSuffix";
-import { filterRolesByTitle, ROLE_TITLE, getMostRecentRole } from "../../models/util/RoleUtilities";
+import { filterRolesByTitle, ROLE_TITLE } from "../../models/util/RoleUtilities";
 
 function writeBiography(
   person: Person,
+  councilMemberRoles: Role[],
   roles: Role[],
   municipalityName: string,
   mattersSponsored: MatterSponsor[]
 ) {
-  const currentRole = getMostRecentRole(roles);
+  const mostRecentCouncilMemberRole = councilMemberRoles[0];
   // names of the bodies that the person is a part of
   const chairBodyNames = filterRolesByTitle(roles, ROLE_TITLE.CHAIR)
     .filter((role) => {
@@ -35,24 +36,20 @@ function writeBiography(
     .map((role) => {
       return role.body?.name || "Unknown Board";
     });
-  let rolesAsCurrentRole = 1;
-  if (currentRole.title) {
-    rolesAsCurrentRole = filterRolesByTitle(roles, currentRole.title).length;
-  }
   /* 
     The first paragraph.
   */
   const lastName = person.name
     ? [person.name.substring(person.name.lastIndexOf(" ") + 1, person.name.length)]
     : "Unknown Name";
-  const addressName = `${currentRole.title} ${lastName}`;
-  const introText = `${addressName} is the ${currentRole.title} of ${municipalityName}'s ${currentRole.seat?.name}(${currentRole.seat?.electoral_area}).`;
+  const addressName = `${mostRecentCouncilMemberRole.title} ${lastName}`;
+  const introText = `${addressName} is the ${mostRecentCouncilMemberRole.title} of ${municipalityName}'s ${mostRecentCouncilMemberRole.seat?.name}(${mostRecentCouncilMemberRole.seat?.electoral_area}).`;
   /* 
     The second paragraph.
   */
 
   const termsSentence = `${addressName} is serving their ${ordinalSuffix(
-    rolesAsCurrentRole
+    councilMemberRoles.length
   )} term.`;
   const chairsSentence =
     chairBodyNames.length > 0

--- a/src/containers/PersonContainer/types.ts
+++ b/src/containers/PersonContainer/types.ts
@@ -10,6 +10,12 @@ export interface PersonPageData {
   votes: Vote[];
   /** matters sponsored by the person */
   mattersSponsored: MatterSponsor[];
-  /** roles held by the person */
+  /** roles held by the person with only body populated */
   roles: Role[];
+  /** Councilmember roles with only seat populated */
+  councilMemberRoles: Role[];
+  /** Picture src of the person */
+  personPictureSrc?: string;
+  /** Picture of the seat for the person's recent councilmember role */
+  seatPictureSrc?: string;
 }

--- a/src/models/Role.ts
+++ b/src/models/Role.ts
@@ -24,7 +24,7 @@ export default class Role implements Model {
     this.person_ref = jsonData["person_ref"].id;
     this.seat_ref = jsonData["seat_ref"].id;
     this.start_datetime = firestoreTimestampToDate(jsonData["start_datetime"]);
-    if (jsonData["title"] && jsonData["title"] in ROLE_TITLE) {
+    if (jsonData["title"] && Object.values(ROLE_TITLE).includes(jsonData["title"])) {
       this.title = jsonData["title"];
     } else {
       this.title = ROLE_TITLE.MEMBER;

--- a/src/networking/FileService.ts
+++ b/src/networking/FileService.ts
@@ -1,0 +1,17 @@
+import { FirebaseConfig } from "../app/AppConfigContext";
+
+import ModelService from "./ModelService";
+import { COLLECTION_NAME } from "./PopulationOptions";
+
+import File from "../models/File";
+
+export default class FileService extends ModelService {
+  constructor(firebaseConfig: FirebaseConfig) {
+    super(COLLECTION_NAME.File, firebaseConfig);
+  }
+
+  async getFileById(id: string): Promise<File> {
+    const networkResponse = this.networkService.getDocument(id, COLLECTION_NAME.File);
+    return this.createModel(networkResponse, File, `getFileById(${id})`) as Promise<File>;
+  }
+}

--- a/src/networking/NetworkService.ts
+++ b/src/networking/NetworkService.ts
@@ -170,27 +170,29 @@ export class NetworkService {
       });
       if (populationOptions && populationOptions.toPopulate) {
         const collatePromises: Promise<NetworkResponse>[] = [];
-        querySnapshotData.forEach((doc) => {
+        for (const doc of querySnapshotData) {
           //Create cascade for each doc
           const cascade: Promise<NetworkResponse>[] = [];
           const refsToPopulate: string[] = [];
           const parent = new NetworkResponse();
           parent.data = doc;
-          populationOptions?.toPopulate?.forEach((docRefToPopulate: Populate) => {
-            //Get the document reference id
-            const refValueToPopulate = doc[docRefToPopulate.refName].id;
-            const refsCollection = getCollectionForReference(docRefToPopulate.refName);
-            if (refValueToPopulate && refsCollection) {
-              //Add population to cascade
-              cascade.push(
-                this.getDocument(refValueToPopulate, refsCollection, docRefToPopulate.cascade)
-              );
-              refsToPopulate.push(docRefToPopulate.refName);
-            }
-          });
+          populationOptions.toPopulate
+            .filter((docRefToPopulate) => doc[docRefToPopulate.refName])
+            .forEach((docRefToPopulate: Populate) => {
+              //Get the document reference id
+              const refValueToPopulate = doc[docRefToPopulate.refName].id;
+              const refsCollection = getCollectionForReference(docRefToPopulate.refName);
+              if (refValueToPopulate && refsCollection) {
+                //Add population to cascade
+                cascade.push(
+                  this.getDocument(refValueToPopulate, refsCollection, docRefToPopulate.cascade)
+                );
+                refsToPopulate.push(docRefToPopulate.refName);
+              }
+            });
           //Add collated document data promise for each doc
           collatePromises.push(this.collateDocumentData(cascade, refsToPopulate, parent));
-        });
+        }
         //Get all the network responses
         const networkRespones = await Promise.all(collatePromises);
         //Collect only the response data, each response data is non-null

--- a/src/networking/NetworkService.ts
+++ b/src/networking/NetworkService.ts
@@ -211,11 +211,9 @@ export class NetworkService {
 
   /** Download json from the given uri in firestorage */
   async downloadJson(uri: string): Promise<NetworkResponse> {
-    const storage = getStorage();
-    const pathReference = ref(storage, uri);
     const response = new NetworkResponse();
     try {
-      const url = await getDownloadURL(pathReference);
+      const url = await this.getDownloadUrl(uri);
       const file = await fetch(url).then((res) => res.json());
       if (!file) {
         throw new Error(`No JSON found for uri: ${uri}`);
@@ -227,5 +225,12 @@ export class NetworkService {
     } finally {
       return Promise.resolve(response);
     }
+  }
+
+  /**Get the download URl */
+  async getDownloadUrl(uri: string): Promise<string> {
+    const storage = getStorage();
+    const pathReference = ref(storage, uri);
+    return await getDownloadURL(pathReference);
   }
 }

--- a/src/stories/model-mocks/imageUrl.ts
+++ b/src/stories/model-mocks/imageUrl.ts
@@ -1,0 +1,5 @@
+function mockImageUrl(width: number, height: number, name: string): string {
+  return `https://via.placeholder.com/${width}x${height}?text=${name.split(" ").join("+")}`;
+}
+
+export { mockImageUrl };


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  ⚠️⚠️ Please do the following before submitting: ⚠️⚠️

  - Read the CONTRIBUTING.md guide and make sure you've followed all the steps given.
  - Ensure that the code is up-to-date with the `main` branch.
  - Provide or update documentation for any feature added by your pull request.
  - Provide relevant tests for your feature or bug fix.

  ❗️ Also: ❗️

  Please name your pull request {development-type}/{short-description}.
  For example: feature/read-tiff-files
-->

### Link to Relevant Issue

This pull request resolves #153 

### Description of Changes

Retrieve and display the person's picture src and seat's picture src.

Added a `getDownloadUrl` method to `NetworkService` to retrieve the URL.

----
I modified the data retrieved by the Person Page a bit to reduce the number of requests to firestore. The person page needs "Councilmember" roles with only `Seat` populated, the rest of the roles need just the `Body` populated. I separated out these two calls to avoid unnecessary population. I could add another `where` (where("title" != "Councilmember"))clause to `getPopulatedRolesByPersonId` so it only retrieve non-councilmember roles, but the seattle-staging DB was complaining about the composite index hasn't been created.


### Link to Forked Storybook Site

See [deployment](https://tohuynh.github.io/cdp-frontend/#/people/e54faa3434c9) for council member and seat picutres.
