### PR TITLE
admin/remove-external-deps-from-bundle

### DIFF
--- a/vite.lib.config.js
+++ b/vite.lib.config.js
@@ -2,6 +2,8 @@ import path from "path";
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 
+import { dependencies } from "./package.json"
+
 export default defineConfig({
   plugins: [
     react({
@@ -21,7 +23,7 @@ export default defineConfig({
     rollupOptions: {
       // make sure to externalize deps that shouldn't be bundled
       // into your library
-      external: ["react"],
+      external: [...Object.keys(dependencies), "react"],
       output: {
         // Provide global variables to use in the UMD build
         // for externalized deps


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  ⚠️⚠️ Please do the following before submitting: ⚠️⚠️

  - Read the CONTRIBUTING.md guide and make sure you've followed all the steps given.
  - Ensure that the code is up-to-date with the `main` branch.
  - Provide or update documentation for any feature added by your pull request.
  - Provide relevant tests for your feature or bug fix.

  ❗️ Also: ❗️

  Please name your pull request {development-type}/{short-description}.
  For example: feature/read-tiff-files
-->

I'm not 100% sure about this. The cause of the error was because `moment.js` was included in our bundle (index.umd.js and index.es.js) which can include unresolvable imports like `./locale` (because it doesn't know it's supposed to find `locale` in `node_modules`.

I removed the external deps from our bundle by adding them to the `external` field in `vite.lib.config.js`. I don't know some of the names for these external modules (that should be added to `output.globals`). So I let vite guess their names based on the usage. It seems to work fine though.

I copied the content of `cdp-frontend/dist` into `king-county/web/node_modules/@councildataproject/cdp-frontend/dist` and then ran `start` and `build`. It seems to work fine.
