### PR TITLE
feature/link-event-minutes-item-to-matter-page

### DIFF
--- a/src/components/Details/MinutesItemsList/MinutesItemsList.tsx
+++ b/src/components/Details/MinutesItemsList/MinutesItemsList.tsx
@@ -4,9 +4,10 @@ import styled from "@emotion/styled";
 import DocumentsList from "./DocumentsList";
 
 import { Item } from "./types";
+import { Link } from "react-router-dom";
 
 const ListItem = styled.li({
-  "& > div:first-of-type": {
+  "& > div:first-of-type, & > a:first-of-type": {
     // bold the minutes item's name
     fontWeight: 600,
   },
@@ -25,7 +26,11 @@ const MinutesItemsList: FC<MinutesItemsListProps> = ({ minutesItems }: MinutesIt
       {minutesItems.map((elem) => {
         return (
           <ListItem key={elem.name}>
-            <div>{elem.name}</div>
+            {elem.matter_ref ? (
+              <Link to={`/matters/${elem.matter_ref}`}>{elem.name}</Link>
+            ) : (
+              <div>{elem.name}</div>
+            )}
             {elem.description && <div>{elem.description}</div>}
             <DocumentsList documents={elem.documents} />
           </ListItem>

--- a/src/components/Details/MinutesItemsList/MinutesItemsList.tsx
+++ b/src/components/Details/MinutesItemsList/MinutesItemsList.tsx
@@ -1,15 +1,25 @@
 import React, { FC } from "react";
 import styled from "@emotion/styled";
-
-import DocumentsList from "./DocumentsList";
-
-import { Item } from "./types";
 import { Link } from "react-router-dom";
 
+import DocumentsList from "./DocumentsList";
+import ChevronDownIcon from "../../Shared/ChevronDownIcon";
+
+import { Item } from "./types";
+
 const ListItem = styled.li({
-  "& > div:first-of-type, & > a:first-of-type": {
+  "& > div:first-of-type": {
     // bold the minutes item's name
     fontWeight: 600,
+  },
+  "& > a": {
+    display: "flex",
+    alignItems: "center",
+  },
+  "& > a > svg": {
+    width: "1rem",
+    height: "1rem",
+    rotate: "-90deg",
   },
 });
 
@@ -26,10 +36,11 @@ const MinutesItemsList: FC<MinutesItemsListProps> = ({ minutesItems }: MinutesIt
       {minutesItems.map((elem) => {
         return (
           <ListItem key={elem.name}>
-            {elem.matter_ref ? (
-              <Link to={`/matters/${elem.matter_ref}`}>{elem.name}</Link>
-            ) : (
-              <div>{elem.name}</div>
+            <div>{elem.name}</div>
+            {elem.matter_ref && (
+              <Link to={`/matters/${elem.matter_ref}`}>
+                {"Go to Full Legislation Details"} <ChevronDownIcon />
+              </Link>
             )}
             {elem.description && <div>{elem.description}</div>}
             <DocumentsList documents={elem.documents} />

--- a/src/components/Details/MinutesItemsList/types.ts
+++ b/src/components/Details/MinutesItemsList/types.ts
@@ -7,7 +7,7 @@ export interface Document {
   url: string;
 }
 
-export interface Item extends Pick<MinutesItem, "name" | "description"> {
+export interface Item extends Pick<MinutesItem, "name" | "description" | "matter_ref"> {
   /*Array of attachments for a given minutes item*/
   documents?: Document[];
 }

--- a/src/containers/EventContainer/EventInfoTabs.tsx
+++ b/src/containers/EventContainer/EventInfoTabs.tsx
@@ -37,6 +37,7 @@ const EventInfoTabs: FC<EventInfoTabsProps> = ({
       return {
         name: minutes_item?.name as string,
         description: minutes_item?.description,
+        matter_ref: minutes_item?.matter_ref,
         documents:
           files && files.length > 0
             ? files.map(({ name, uri }) => {


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  ⚠️⚠️ Please do the following before submitting: ⚠️⚠️

  - Read the CONTRIBUTING.md guide and make sure you've followed all the steps given.
  - Ensure that the code is up-to-date with the `main` branch.
  - Provide or update documentation for any feature added by your pull request.
  - Provide relevant tests for your feature or bug fix.

  ❗️ Also: ❗️

  Please name your pull request {development-type}/{short-description}.
  For example: feature/read-tiff-files
-->

### Link to Relevant Issue

This pull request resolves #167 

### Description of Changes

If the minutes item has a `matter_ref` link it to the currently non-existent matter page.
I decided not to add "Full Matter/Legislation Details" and just made the `matter.name` the link. I think the link alone is sufficient to convey that the link is for the matter/legislation page.

### Link to Forked Storybook Site

![image](https://user-images.githubusercontent.com/37560480/149243288-73a057f2-d3ef-41d2-a03e-e55732e3a265.png)

