### PR TITLE
fix/chevron-icon-rotation

### DIFF
--- a/src/components/Details/MinutesItemsList/MinutesItemsList.tsx
+++ b/src/components/Details/MinutesItemsList/MinutesItemsList.tsx
@@ -19,7 +19,7 @@ const ListItem = styled.li({
   "& > a > svg": {
     width: "1rem",
     height: "1rem",
-    rotate: "-90deg",
+    transform: "rotate(-90deg)",
   },
 });
 


### PR DESCRIPTION
Fix a bug introduced in #170. `rotate` isn't widely supported, use `transform` instead to rotate the icon -90 deg.