### PR TITLE
enhancement/make-nav-text-larger (#127)

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -63,6 +63,10 @@ function App() {
               font-size: 100%;
             }
 
+            body {
+              font-family: Inter, X-LocaleSpecific, sans-serif;
+            }
+
             * {
               box-sizing: initial;
             }

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { HashRouter as Router, Route, Switch } from "react-router-dom";
 import styled from "@emotion/styled";
+import { Global, css } from "@emotion/react";
 
 import { useAppConfigContext } from "./AppConfigContext";
 import useDocumentTitle from "../hooks/useDocumentTitle";
@@ -56,6 +57,17 @@ function App() {
   return (
     <>
       <Router basename="/">
+        <Global
+          styles={css`
+            html {
+              font-size: 100%;
+            }
+
+            * {
+              box-sizing: initial;
+            }
+          `}
+        />
         <FlexContainer>
           <Header municipalityName={municipality.name} />
           <Main>

--- a/src/components/Layout/Header/Header.tsx
+++ b/src/components/Layout/Header/Header.tsx
@@ -8,7 +8,9 @@ import { screenWidths } from "../../../styles/mediaBreakpoints";
 
 const CDPLogo = styled.div({
   float: "left",
-  marginRight: "48px",
+  maxHeight: "64px",
+  maxWidth: "64px",
+  marginTop: "12px",
 });
 
 const HamburgerMenuButton = styled.button({
@@ -51,16 +53,8 @@ const Header: FC<HeaderProps> = ({ municipalityName }: HeaderProps) => {
             >
               Menu
             </HamburgerMenuButton>
-            <CDPLogo>
-              <a
-                href="https://councildataproject.org"
-                className="cdp-icon-black-bg-transparent-size-256"
-                title={strings.council_data_project}
-                style={{
-                  maxHeight: "64px",
-                  maxWidth: "64px",
-                }}
-              >
+            <CDPLogo className="cdp-icon-black-bg-transparent-size-256">
+              <a href="https://councildataproject.org" title={strings.council_data_project}>
                 {strings.council_data_project}
               </a>
             </CDPLogo>
@@ -70,7 +64,7 @@ const Header: FC<HeaderProps> = ({ municipalityName }: HeaderProps) => {
               className="mzp-c-navigation-items"
               id="patterns.organisms.navigation.navigation"
             >
-              <div className="mzp-c-navigation-menu">
+              <div className="mzp-c-navigation-container">
                 <nav className="mzp-c-menu mzp-is-basic">
                   <ul className="mzp-c-menu-category-list">
                     <li className="mzp-c-menu-category">

--- a/src/components/Layout/Header/Header.tsx
+++ b/src/components/Layout/Header/Header.tsx
@@ -8,8 +8,6 @@ import { screenWidths } from "../../../styles/mediaBreakpoints";
 
 const CDPLogo = styled.div({
   float: "left",
-  maxHeight: "64px",
-  maxWidth: "64px",
   marginTop: "12px",
 });
 
@@ -53,8 +51,13 @@ const Header: FC<HeaderProps> = ({ municipalityName }: HeaderProps) => {
             >
               Menu
             </HamburgerMenuButton>
-            <CDPLogo className="cdp-icon-black-bg-transparent-size-256">
-              <a href="https://councildataproject.org" title={strings.council_data_project}>
+            <CDPLogo>
+              <a
+                className="cdp-icon-black-bg-transparent-size-256"
+                style={{ maxHeight: "64px", maxWidth: "64px" }}
+                href="https://councildataproject.org"
+                title={strings.council_data_project}
+              >
                 {strings.council_data_project}
               </a>
             </CDPLogo>


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  ⚠️⚠️ Please do the following before submitting: ⚠️⚠️

  - Read the CONTRIBUTING.md guide and make sure you've followed all the steps given.
  - Ensure that the code is up-to-date with the `main` branch.
  - Provide or update documentation for any feature added by your pull request.
  - Provide relevant tests for your feature or bug fix.

  ❗️ Also: ❗️

  Please name your pull request {development-type}/{short-description}.
  For example: feature/read-tiff-files
-->

### Link to Relevant Issue

This pull request resolves #127 

### Description of Changes

*  Add global styles for font-size consistency with the main cdp website

* Fix header styles to make it consistent with the main cdp website's header
--------------------------------------------------------------------------------------------
The inconsistencies in the nav bar between the sites were due to the Semantic-ui  stylesheet setting the font-size of the document to 14px, while on the org's website the font-size was unchanged(100%) by the Mozilla stylesheet.

Also, the box-sizing for the two sites were different, which resulted in the org's website having more vertical spacing in the nav area.

### Link to Forked Storybook Site
https://tevinab.github.io/cdp-frontend/#/

