### PR TITLE
fix/share-event-page-modal-sizing

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -66,10 +66,6 @@ function App() {
             body {
               font-family: Inter, X-LocaleSpecific, sans-serif;
             }
-
-            * {
-              box-sizing: initial;
-            }
           `}
         />
         <FlexContainer>

--- a/src/components/Layout/Header/Header.tsx
+++ b/src/components/Layout/Header/Header.tsx
@@ -6,6 +6,10 @@ import styled from "@emotion/styled";
 import { strings } from "../../../assets/LocalizedStrings";
 import { screenWidths } from "../../../styles/mediaBreakpoints";
 
+const Navigation = styled.div({
+  boxSizing: "initial",
+});
+
 const CDPLogo = styled.div({
   float: "left",
   marginTop: "12px",
@@ -41,7 +45,7 @@ const Header: FC<HeaderProps> = ({ municipalityName }: HeaderProps) => {
 
   return (
     <header>
-      <div className="mzp-c-navigation">
+      <Navigation className="mzp-c-navigation">
         <div className="mzp-c-navigation-l-content">
           <div className="mzp-c-navigation-container">
             <HamburgerMenuButton
@@ -91,7 +95,7 @@ const Header: FC<HeaderProps> = ({ municipalityName }: HeaderProps) => {
             </NavItems>
           </div>
         </div>
-      </div>
+      </Navigation>
     </header>
   );
 };


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  ⚠️⚠️ Please do the following before submitting: ⚠️⚠️

  - Read the CONTRIBUTING.md guide and make sure you've followed all the steps given.
  - Ensure that the code is up-to-date with the `main` branch.
  - Provide or update documentation for any feature added by your pull request.
  - Provide relevant tests for your feature or bug fix.

  ❗️ Also: ❗️

  Please name your pull request {development-type}/{short-description}.
  For example: feature/read-tiff-files
-->

### Link to Relevant Issue

This pull request resolves #

### Description of Changes

_Include a description of the proposed changes._
#177 introduced a wildcard rule 
```
* {
  box-sizing: initial;
}
```
that caused the share event page modal body to have unaligned widths

![image](https://user-images.githubusercontent.com/37560480/150215763-2b83f16a-e275-442f-a5f9-ab739f499a4f.png)

This PR just removes the wildcard box-sizing rule to the navigation element in the header so the header element still has the same size as the org website.

### Link to Forked Storybook Site

_If component changes (especially visual changes) are contained in this PR, we ask that you provide a link to a publicly viewable version of the Storybook docs site, so PR reviewers can see your changes without having to install and view your code locally._

_Please see `CONTRIBUTING.md` for directions on how this can be done._

![image](https://user-images.githubusercontent.com/37560480/150216079-6f179382-35c1-4e47-b96e-51594c4b4263.png)
