### PR TITLE
fix/temp-remove-matter-links

### DIFF
--- a/src/components/Details/MinutesItemsList/MinutesItemsList.tsx
+++ b/src/components/Details/MinutesItemsList/MinutesItemsList.tsx
@@ -37,11 +37,11 @@ const MinutesItemsList: FC<MinutesItemsListProps> = ({ minutesItems }: MinutesIt
         return (
           <ListItem key={elem.name}>
             <div>{elem.name}</div>
-            {elem.matter_ref && (
+            {/* {elem.matter_ref && (
               <Link to={`/matters/${elem.matter_ref}`}>
                 {"Go to Full Legislation Details"} <ChevronDownIcon />
               </Link>
-            )}
+            )} */}
             {elem.description && <div>{elem.description}</div>}
             <DocumentsList documents={elem.documents} />
           </ListItem>

--- a/src/components/Details/MinutesItemsList/MinutesItemsList.tsx
+++ b/src/components/Details/MinutesItemsList/MinutesItemsList.tsx
@@ -1,9 +1,9 @@
 import React, { FC } from "react";
 import styled from "@emotion/styled";
-import { Link } from "react-router-dom";
+/* import { Link } from "react-router-dom"; */
 
 import DocumentsList from "./DocumentsList";
-import ChevronDownIcon from "../../Shared/ChevronDownIcon";
+/* import ChevronDownIcon from "../../Shared/ChevronDownIcon"; */
 
 import { Item } from "./types";
 

--- a/src/components/Tables/MeetingVotesTableRow/MeetingVotesTableRow.tsx
+++ b/src/components/Tables/MeetingVotesTableRow/MeetingVotesTableRow.tsx
@@ -98,7 +98,7 @@ function VoteCell(isExpanded: boolean, votes: IndividualMeetingVote[], isMobile:
 
 const MeetingVotesTableRow = ({
   index,
-  legislationLink,
+  /* legislationLink, */
   legislationName,
   legislationDescription,
   councilDecision,

--- a/src/components/Tables/MeetingVotesTableRow/MeetingVotesTableRow.tsx
+++ b/src/components/Tables/MeetingVotesTableRow/MeetingVotesTableRow.tsx
@@ -120,7 +120,10 @@ const MeetingVotesTableRow = ({
       }}
     >
       <div>
-        <Link to={legislationLink}>{legislationName}</Link>
+        {/* <Link to={legislationLink}>{legislationName}</Link> */}
+        <p className="mzp-c-card-desc" style={{ fontWeight: 600, marginBottom: 0 }}>
+          {legislationName}
+        </p>
         {!isMobile && <p>{legislationDescription}</p>}
       </div>
       <DecisionResult result={councilDecision} />

--- a/src/components/Tables/VotingTableRow/VotingTableRow.tsx
+++ b/src/components/Tables/VotingTableRow/VotingTableRow.tsx
@@ -34,7 +34,7 @@ export type VotingTableRowProps = {
 
 const VotingTableRow = ({
   index,
-  legislationLink,
+  /* legislationLink, */
   legislationName,
   legislationTags,
   voteDecision,

--- a/src/components/Tables/VotingTableRow/VotingTableRow.tsx
+++ b/src/components/Tables/VotingTableRow/VotingTableRow.tsx
@@ -58,7 +58,10 @@ const VotingTableRow = ({
       columnDistribution={columnDistribution}
     >
       <React.Fragment>
-        <Link to={legislationLink}>{legislationName}</Link>
+        {/* <Link to={legislationLink}>{legislationName}</Link> */}
+        <p className="mzp-c-card-desc" style={{ fontWeight: 600, marginBottom: 0 }}>
+          {legislationName}
+        </p>
         {!isMobile && <p className="mzp-c-card-desc">{legislationTagsString}</p>}
       </React.Fragment>
       <DecisionResult result={voteDecision} />


### PR DESCRIPTION
Temporarily replaces the matter links(that leads to the matter page that doesn't exist atm) with `p` that is bolded.

![image](https://user-images.githubusercontent.com/37560480/150457449-33f3a9f0-dae9-44b3-99b9-e6af2d40869d.png)
