### PR TITLE
component/icon-updates

### DIFF
--- a/src/components/Shared/AbstainIcon.tsx
+++ b/src/components/Shared/AbstainIcon.tsx
@@ -4,17 +4,23 @@ const AbstainIcon = () => {
   return (
     <svg
       className="cdp-light-purple"
-      fill="none"
-      stroke="currentColor"
       viewBox="0 0 24 24"
+      fill="none"
       xmlns="http://www.w3.org/2000/svg"
     >
-      <path
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        strokeWidth={2}
-        d="M5 12h.01M12 12h.01M19 12h.01M6 12a1 1 0 11-2 0 1 1 0 012 0zm7 0a1 1 0 11-2 0 1 1 0 012 0zm7 0a1 1 0 11-2 0 1 1 0 012 0z"
-      />
+      <g id="Group 1">
+        <g id="Frame 1">
+          <circle id="Ellipse 1" cx="12" cy="12" r="9" stroke="currentColor" strokeWidth="2" />
+          <circle id="Ellipse 2" cx="12" cy="12" r="4" stroke="currentColor" strokeWidth="2" />
+          <path
+            id="Line 1"
+            d="M8.00001 16L16 7.99998"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+          />
+        </g>
+      </g>
     </svg>
   );
 };

--- a/src/components/Shared/InProgressIcon.tsx
+++ b/src/components/Shared/InProgressIcon.tsx
@@ -3,17 +3,17 @@ import React from "react";
 const InProgressIcon = () => {
   return (
     <svg
-      className="cdp-in-progress_orange"
       xmlns="http://www.w3.org/2000/svg"
       fill="none"
       viewBox="0 0 24 24"
       stroke="currentColor"
+      className="cdp-in-progress_orange"
     >
       <path
         strokeLinecap="round"
         strokeLinejoin="round"
-        strokeWidth={2}
-        d="M8 10h.01M12 10h.01M16 10h.01M9 16H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-5l-5 5v-5z"
+        strokeWidth="2"
+        d="M8 12h.01M12 12h.01M16 12h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
       />
     </svg>
   );

--- a/src/components/Shared/RejectedIcon.tsx
+++ b/src/components/Shared/RejectedIcon.tsx
@@ -3,8 +3,8 @@ import React from "react";
 const RejectedIcon = () => {
   return (
     <svg
-      className="cdp-rejected-red"
       xmlns="http://www.w3.org/2000/svg"
+      className="cdp-rejected-red"
       fill="none"
       viewBox="0 0 24 24"
       stroke="currentColor"
@@ -12,8 +12,8 @@ const RejectedIcon = () => {
       <path
         strokeLinecap="round"
         strokeLinejoin="round"
-        strokeWidth={2}
-        d="M18.364 18.364A9 9 0 005.636 5.636m12.728 12.728A9 9 0 015.636 5.636m12.728 12.728L5.636 5.636"
+        strokeWidth="2"
+        d="M10 14l2-2m0 0l2-2m-2 2l-2-2m2 2l2 2m7-2a9 9 0 11-18 0 9 9 0 0118 0z"
       />
     </svg>
   );


### PR DESCRIPTION
### Link to Relevant Issue

This pull request resolves #198 

### Description of Changes

Update 3 icons: Reject, Abstain, and InProgress.

### Link to Forked Storybook Site

They are best visible [here](https://brianl3.github.io/cdp-frontend/?path=/story/library-tables-meeting-votes-table--many-legislation-rows-and-votes). 