### PR TITLE
feature/optimize-person-page

### DIFF
--- a/src/components/Details/TranscriptFull/TranscriptFull.stories.tsx
+++ b/src/components/Details/TranscriptFull/TranscriptFull.stories.tsx
@@ -6,6 +6,8 @@ import { Story, Meta } from "@storybook/react";
 import TranscriptFull, { TranscriptFullProps } from "./TranscriptFull";
 import { TranscriptItemRef } from "../TranscriptItem/TranscriptItem";
 
+import { mockSentences } from "../../../stories/model-mocks/sentence";
+
 export default {
   component: TranscriptFull,
   title: "Library/Details/Transcript Full",
@@ -13,19 +15,11 @@ export default {
 
 const Template: Story<TranscriptFullProps> = (args) => <TranscriptFull {...args} />;
 
+const exampleSentences = mockSentences(2, 10);
+
 export const transcriptFull = Template.bind({});
 transcriptFull.args = {
-  sentences: Array.from({ length: 20 }).map((_, i) => ({
-    session_index: 0,
-    index: i,
-    start_time: i,
-    text: `This is a sentence${i}.`,
-    speaker_index: i,
-    speaker_name: "Lisa Herbold",
-    speaker_id: "lisa-herbold",
-    speaker_pictureSrc:
-      "https://www.seattle.gov/images/Council/Members/Herbold/Herbold_225x225.jpg",
-  })),
-  transcriptItemsRefs: Array.from({ length: 20 }).map(() => createRef<TranscriptItemRef>()),
+  sentences: exampleSentences,
+  transcriptItemsRefs: exampleSentences.map(() => createRef<TranscriptItemRef>()),
   jumpToVideoClip: (_, startTime) => action(`jump to video clip at ${startTime}`),
 };

--- a/src/components/Details/TranscriptSearch/TranscriptSearch.stories.tsx
+++ b/src/components/Details/TranscriptSearch/TranscriptSearch.stories.tsx
@@ -8,6 +8,8 @@ import { initialFetchDataState } from "../../../containers/FetchDataContainer/us
 
 import TranscriptSearch, { TranscriptSearchProps } from "./TranscriptSearch";
 
+import { mockSentences } from "../../../stories/model-mocks/sentence";
+
 export default {
   component: TranscriptSearch,
   title: "Library/Details/Transcript Search",
@@ -27,27 +29,7 @@ Default.args = {
   searchQuery: "sentence",
   sentences: {
     ...initialFetchDataState,
-    data: [
-      {
-        session_index: 0,
-        index: 0,
-        start_time: 1.5,
-        text: "This is a sentence.",
-        speaker_index: 0,
-        speaker_name: "Lisa Herbold",
-        speaker_id: "lisa-herbold",
-        speaker_pictureSrc:
-          "https://www.seattle.gov/images/Council/Members/Herbold/Herbold_225x225.jpg",
-      },
-      {
-        session_index: 0,
-        index: 1,
-        start_time: 2,
-        text: "This is another sentence.",
-        speaker_name: "Unknown",
-        speaker_index: 1,
-      },
-    ],
+    data: mockSentences(1, 2),
   },
   jumpToVideoClip: (sessionIndex, startTime) => action("jump to video clip"),
   jumpToTranscript: (sentenceIndex) => action("jump to transcript"),
@@ -58,17 +40,7 @@ manySentences.args = {
   searchQuery: "sentence",
   sentences: {
     ...initialFetchDataState,
-    data: Array.from({ length: 200 }).map((_, i) => ({
-      session_index: 0,
-      index: i,
-      start_time: i,
-      text: `This is a sentence ${i}.`,
-      speaker_name: "Lisa Herbold",
-      speaker_id: "lisa-herbold",
-      speaker_index: 0,
-      speaker_pictureSrc:
-        "https://www.seattle.gov/images/Council/Members/Herbold/Herbold_225x225.jpg",
-    })),
+    data: mockSentences(2, 100),
   },
   jumpToVideoClip: (sessionIndex, startTime) => action("jump to video clip"),
   jumpToTranscript: (sentenceIndex) => action("jump to transcript"),

--- a/src/components/Details/TranscriptSearch/TranscriptSearch.stories.tsx
+++ b/src/components/Details/TranscriptSearch/TranscriptSearch.stories.tsx
@@ -4,6 +4,8 @@ import React from "react";
 import { action } from "@storybook/addon-actions";
 import { Story, Meta } from "@storybook/react";
 
+import { initialFetchDataState } from "../../../containers/FetchDataContainer/useFetchData";
+
 import TranscriptSearch, { TranscriptSearchProps } from "./TranscriptSearch";
 
 export default {
@@ -23,27 +25,30 @@ const Template: Story<TranscriptSearchProps> = (args) => <TranscriptSearch {...a
 export const Default = Template.bind({});
 Default.args = {
   searchQuery: "sentence",
-  sentences: [
-    {
-      session_index: 0,
-      index: 0,
-      start_time: 1.5,
-      text: "This is a sentence.",
-      speaker_index: 0,
-      speaker_name: "Lisa Herbold",
-      speaker_id: "lisa-herbold",
-      speaker_pictureSrc:
-        "https://www.seattle.gov/images/Council/Members/Herbold/Herbold_225x225.jpg",
-    },
-    {
-      session_index: 0,
-      index: 1,
-      start_time: 2,
-      text: "This is another sentence.",
-      speaker_name: "Unknown",
-      speaker_index: 1,
-    },
-  ],
+  sentences: {
+    ...initialFetchDataState,
+    data: [
+      {
+        session_index: 0,
+        index: 0,
+        start_time: 1.5,
+        text: "This is a sentence.",
+        speaker_index: 0,
+        speaker_name: "Lisa Herbold",
+        speaker_id: "lisa-herbold",
+        speaker_pictureSrc:
+          "https://www.seattle.gov/images/Council/Members/Herbold/Herbold_225x225.jpg",
+      },
+      {
+        session_index: 0,
+        index: 1,
+        start_time: 2,
+        text: "This is another sentence.",
+        speaker_name: "Unknown",
+        speaker_index: 1,
+      },
+    ],
+  },
   jumpToVideoClip: (sessionIndex, startTime) => action("jump to video clip"),
   jumpToTranscript: (sentenceIndex) => action("jump to transcript"),
 };
@@ -51,17 +56,20 @@ Default.args = {
 export const manySentences = Template.bind({});
 manySentences.args = {
   searchQuery: "sentence",
-  sentences: Array.from({ length: 200 }).map((_, i) => ({
-    session_index: 0,
-    index: i,
-    start_time: i,
-    text: `This is a sentence ${i}.`,
-    speaker_name: "Lisa Herbold",
-    speaker_id: "lisa-herbold",
-    speaker_index: 0,
-    speaker_pictureSrc:
-      "https://www.seattle.gov/images/Council/Members/Herbold/Herbold_225x225.jpg",
-  })),
+  sentences: {
+    ...initialFetchDataState,
+    data: Array.from({ length: 200 }).map((_, i) => ({
+      session_index: 0,
+      index: i,
+      start_time: i,
+      text: `This is a sentence ${i}.`,
+      speaker_name: "Lisa Herbold",
+      speaker_id: "lisa-herbold",
+      speaker_index: 0,
+      speaker_pictureSrc:
+        "https://www.seattle.gov/images/Council/Members/Herbold/Herbold_225x225.jpg",
+    })),
+  },
   jumpToVideoClip: (sessionIndex, startTime) => action("jump to video clip"),
   jumpToTranscript: (sentenceIndex) => action("jump to transcript"),
 };

--- a/src/components/Shared/PlaceHolder.tsx
+++ b/src/components/Shared/PlaceHolder.tsx
@@ -29,7 +29,7 @@ const Placeholder = styled.div<{ isLoading: boolean }>((props) => ({
   },
   "& > div:nth-of-type(2)": {
     // the place holder ui is visible when content is loading
-    opacity: props.isLoading ? 1 : 0,
+    display: props.isLoading ? "block" : "none",
     width: "100%",
     height: "100%",
     backgroundColor: "rgba(0, 0, 0, 0.11)",

--- a/src/components/Shared/PlaceHolder.tsx
+++ b/src/components/Shared/PlaceHolder.tsx
@@ -1,0 +1,67 @@
+import React, { CSSProperties, FC, ReactNode } from "react";
+import { keyframes } from "@emotion/react";
+import styled from "@emotion/styled";
+
+const waveKeyframe = keyframes`
+  0% {
+    transform: translateX(-100%);
+  }
+  50% {
+    /* +0.5s of delay between each loop */
+    transform: translateX(100%);
+  }
+  100% {
+    transform: translateX(100%);
+  }
+`;
+
+const Placeholder = styled.div<{ isLoading: boolean }>((props) => ({
+  position: "relative",
+  width: "100%",
+  height: "100%",
+  "& > div, & > div:nth-of-type(2):after": {
+    position: "absolute",
+    inset: 0,
+  },
+  "& > div:first-of-type": {
+    // the content is visible when it's finished loading
+    opacity: props.isLoading ? 0 : 1,
+  },
+  "& > div:nth-of-type(2)": {
+    // the place holder ui is visible when content is loading
+    opacity: props.isLoading ? 1 : 0,
+    width: "100%",
+    height: "100%",
+    backgroundColor: "rgba(0, 0, 0, 0.11)",
+    overflow: "hidden",
+  },
+  "& > div:nth-of-type(2):after": {
+    // the `after` slide through the placeholder to create a horizontal wave/loading effect
+    content: '""',
+    animation: `${waveKeyframe} 1.6s linear 0.5s infinite`,
+    backgroundImage: "linear-gradient(90deg, transparent, rgba(0, 0, 0, 0.04), transparent)",
+    transform: "translateX(-100%)",
+  },
+}));
+
+interface PlaceholderProps {
+  contentIsLoading: boolean;
+  children: ReactNode;
+  placeholderStyle?: CSSProperties;
+}
+
+/**A wrapper to show a placeholder while the content is loading */
+const PlaceholderWrapper: FC<PlaceholderProps> = ({
+  contentIsLoading,
+  children,
+  placeholderStyle,
+}: PlaceholderProps) => {
+  return (
+    <Placeholder isLoading={contentIsLoading}>
+      <div>{children}</div>
+      <div style={placeholderStyle} />
+    </Placeholder>
+  );
+};
+
+export default PlaceholderWrapper;

--- a/src/containers/EventContainer/EventContainer.stories.tsx
+++ b/src/containers/EventContainer/EventContainer.stories.tsx
@@ -5,7 +5,8 @@ import EventContainer, { EventContainerProps } from "./EventContainer";
 import { initialFetchDataState } from "../FetchDataContainer/useFetchData";
 
 import { EVENT_MINUTES_ITEM_DECISION, VOTE_DECISION } from "../../models/constants";
-import { ECSentence } from "./types";
+
+import { mockSentences } from "../../stories/model-mocks/sentence";
 
 export default {
   component: EventContainer,
@@ -13,20 +14,6 @@ export default {
 } as Meta;
 
 const Template: Story<EventContainerProps> = (args) => <EventContainer {...args} />;
-
-const sentences: ECSentence[] = [];
-for (let sessionIndex = 0; sessionIndex < 2; sessionIndex++) {
-  for (let sentenceIndex = 0; sentenceIndex < 10; sentenceIndex++) {
-    sentences.push({
-      session_index: sessionIndex,
-      index: sessionIndex * 10 + sentenceIndex,
-      start_time: sentenceIndex,
-      text: `This is a sentence ${sessionIndex * 10 + sentenceIndex}.`,
-      speaker_index: sentenceIndex,
-      speaker_name: `Speaker ${sentenceIndex}`,
-    });
-  }
-}
 
 export const event = Template.bind({});
 event.args = {
@@ -48,7 +35,7 @@ event.args = {
       session_index: 2,
     },
   ],
-  sentences: { ...initialFetchDataState, data: sentences },
+  sentences: { ...initialFetchDataState, data: mockSentences(2, 10) },
   eventMinutesItems: [
     {
       id: "test1",

--- a/src/containers/EventContainer/EventContainer.stories.tsx
+++ b/src/containers/EventContainer/EventContainer.stories.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { Story, Meta } from "@storybook/react";
 
 import EventContainer, { EventContainerProps } from "./EventContainer";
+import { initialFetchDataState } from "../FetchDataContainer/useFetchData";
 
 import { EVENT_MINUTES_ITEM_DECISION, VOTE_DECISION } from "../../models/constants";
 import { ECSentence } from "./types";
@@ -47,7 +48,7 @@ event.args = {
       session_index: 2,
     },
   ],
-  sentences: sentences,
+  sentences: { ...initialFetchDataState, data: sentences },
   eventMinutesItems: [
     {
       id: "test1",

--- a/src/containers/EventContainer/EventContainer.tsx
+++ b/src/containers/EventContainer/EventContainer.tsx
@@ -103,8 +103,8 @@ const EventContainer: FC<EventContainerProps> = ({
 
   //Create the TranscriptItemsRefs to create jumpToTranscript callback
   const transcriptItemsRefs = useMemo(() => {
-    return (sentences || []).map(() => createRef<TranscriptItemRef>());
-  }, [sentences]);
+    return (sentences.data || []).map(() => createRef<TranscriptItemRef>());
+  }, [sentences.data]);
   const [currentTranscriptItem, setCurrentTranscriptItem] = useState<number>();
   const jumpToTranscript = useCallback(
     (sentenceIndex: number) => {

--- a/src/containers/EventContainer/EventInfoTabs.tsx
+++ b/src/containers/EventContainer/EventInfoTabs.tsx
@@ -2,6 +2,8 @@ import React, { FC, Dispatch, SetStateAction, RefObject, useMemo } from "react";
 
 import { TabProps } from "semantic-ui-react";
 
+import LazyFetchDataContainer from "../FetchDataContainer/LazyFetchDataContainer";
+import { FetchDataState } from "../FetchDataContainer/useFetchData";
 import { TranscriptFull } from "../../components/Details/TranscriptFull";
 import { TranscriptItemRef } from "../../components/Details/TranscriptItem/TranscriptItem";
 import { MinutesItemsList } from "../../components/Details/MinutesItemsList";
@@ -14,7 +16,7 @@ import { strings } from "../../assets/LocalizedStrings";
 interface EventInfoTabsProps {
   currentInfoTab: number;
   setCurrentInfoTab: Dispatch<SetStateAction<number>>;
-  sentences?: ECSentence[];
+  sentences: FetchDataState<ECSentence[]>;
   transcriptItemsRefs: RefObject<TranscriptItemRef>[];
   eventMinutesItems: ECEventMinutesItem[];
   votes: ECVote[];
@@ -106,14 +108,21 @@ const EventInfoTabs: FC<EventInfoTabsProps> = ({
         menuItem: strings.transcript,
         pane: {
           key: "transcript",
-          content: sentences ? (
-            <TranscriptFull
-              sentences={sentences}
-              transcriptItemsRefs={transcriptItemsRefs}
-              jumpToVideoClip={jumpToVideoClip}
-            />
-          ) : (
-            <div>Fetching transcript...</div>
+          content: (
+            <LazyFetchDataContainer
+              data="transcript"
+              isLoading={sentences.isLoading}
+              error={sentences.error}
+              notFound={!sentences.data || sentences.data.length === 0}
+            >
+              {sentences.data && (
+                <TranscriptFull
+                  sentences={sentences.data}
+                  transcriptItemsRefs={transcriptItemsRefs}
+                  jumpToVideoClip={jumpToVideoClip}
+                />
+              )}
+            </LazyFetchDataContainer>
           ),
         },
       },

--- a/src/containers/EventContainer/types.ts
+++ b/src/containers/EventContainer/types.ts
@@ -8,6 +8,8 @@ import Session from "../../models/Session";
 import Vote from "../../models/Vote";
 import Person from "../../models/Person";
 
+import { FetchDataState } from "../FetchDataContainer/useFetchData";
+
 export interface ECEvent extends Pick<Event, "event_datetime"> {
   body?: Pick<Body, "name">;
 }
@@ -33,7 +35,7 @@ export interface EventData {
   /** Session of the event */
   sessions: ECSession[];
   /** Sentences for the event */
-  sentences?: ECSentence[];
+  sentences: FetchDataState<ECSentence[]>;
   /** Event minutes items of the event */
   eventMinutesItems: ECEventMinutesItem[];
   /** Votes for the event */

--- a/src/containers/FetchDataContainer/LazyFetchDataContainer.tsx
+++ b/src/containers/FetchDataContainer/LazyFetchDataContainer.tsx
@@ -1,0 +1,31 @@
+import React, { FC, ReactNode } from "react";
+
+interface LazyFetchDataContainerProps {
+  data: string;
+  isLoading: boolean;
+  error: Error | null;
+  notFound: boolean;
+  children: ReactNode;
+}
+
+/** The non-blocking version of `FetchDataContainer` -- pair with a component that lazily fetches data. */
+const LazyFetchDataContainer: FC<LazyFetchDataContainerProps> = ({
+  data,
+  isLoading,
+  error,
+  notFound,
+  children,
+}: LazyFetchDataContainerProps) => {
+  if (isLoading) {
+    return <p>{`Fetching ${data}...`}</p>;
+  }
+  if (error) {
+    return <p>{error.message}</p>;
+  }
+  if (notFound) {
+    return <p>{`No ${data} found.`}</p>;
+  }
+  return <>{children}</>;
+};
+
+export default LazyFetchDataContainer;

--- a/src/containers/FetchDataContainer/useFetchData.ts
+++ b/src/containers/FetchDataContainer/useFetchData.ts
@@ -80,7 +80,6 @@ export default function useFetchData<T>(
     const fetch = async () => {
       try {
         dispatch({ type: FetchDataActionType.FETCH_INIT });
-        console.log("fetching", new Date().toISOString());
         const data = await fetchData();
         if (!didCancel) {
           dispatch({ type: FetchDataActionType.FETCH_SUCCESS, payload: data });

--- a/src/containers/FetchDataContainer/useFetchData.ts
+++ b/src/containers/FetchDataContainer/useFetchData.ts
@@ -2,6 +2,12 @@ import { useReducer, useEffect } from "react";
 
 import { createError } from "../../utils/createError";
 
+export const initialFetchDataState = {
+  isLoading: false,
+  error: null,
+  hasFetchRequest: true,
+};
+
 export interface FetchDataState<T> {
   isLoading: boolean;
   data?: T;
@@ -74,6 +80,7 @@ export default function useFetchData<T>(
     const fetch = async () => {
       try {
         dispatch({ type: FetchDataActionType.FETCH_INIT });
+        console.log("fetching", new Date().toISOString());
         const data = await fetchData();
         if (!didCancel) {
           dispatch({ type: FetchDataActionType.FETCH_SUCCESS, payload: data });

--- a/src/containers/PersonContainer/MattersSponsored.tsx
+++ b/src/containers/PersonContainer/MattersSponsored.tsx
@@ -2,6 +2,7 @@ import React, { FC, useMemo } from "react";
 
 import MatterSponsor from "../../models/MatterSponsor";
 
+import LazyFetchDataContainer from "../FetchDataContainer/LazyFetchDataContainer";
 import { FetchDataState } from "../FetchDataContainer/useFetchData";
 
 import Details from "../../components/Shared/Details";
@@ -18,30 +19,28 @@ const MattersSponsored: FC<MattersSponsoredProps> = ({
   mattersSponsored,
 }: MattersSponsoredProps) => {
   const hiddenContent = useMemo(() => {
-    if (mattersSponsored.isLoading) {
-      return <p>Fetching legislations...</p>;
-    }
-
-    if (mattersSponsored.error) {
-      return <p>{mattersSponsored.error.message}</p>;
-    }
-    if (!mattersSponsored.data || mattersSponsored.data.length === 0) {
-      return <p>No legislations found.</p>;
-    }
-
     return (
-      <Ul gap={8}>
-        {mattersSponsored.data.map((matterSponsored) => (
-          <li key={matterSponsored.id}>
-            <dl>
-              <dt>
-                <strong>{matterSponsored.matter?.name}</strong>
-              </dt>
-              <dd>{matterSponsored.matter?.title}</dd>
-            </dl>
-          </li>
-        ))}
-      </Ul>
+      <LazyFetchDataContainer
+        data="legislations"
+        isLoading={mattersSponsored.isLoading}
+        error={mattersSponsored.error}
+        notFound={!mattersSponsored.data || mattersSponsored.data.length === 0}
+      >
+        {mattersSponsored.data && (
+          <Ul gap={8}>
+            {mattersSponsored.data.map((matterSponsored) => (
+              <li key={matterSponsored.id}>
+                <dl>
+                  <dt>
+                    <strong>{matterSponsored.matter?.name}</strong>
+                  </dt>
+                  <dd>{matterSponsored.matter?.title}</dd>
+                </dl>
+              </li>
+            ))}
+          </Ul>
+        )}
+      </LazyFetchDataContainer>
     );
   }, [mattersSponsored]);
 

--- a/src/containers/PersonContainer/MattersSponsored.tsx
+++ b/src/containers/PersonContainer/MattersSponsored.tsx
@@ -1,22 +1,49 @@
-import React, { FC } from "react";
+import React, { FC, useMemo } from "react";
 
 import MatterSponsor from "../../models/MatterSponsor";
+
+import { FetchDataState } from "../FetchDataContainer/useFetchData";
 
 import Details from "../../components/Shared/Details";
 import H2 from "../../components/Shared/H2";
 import Ul from "../../components/Shared/Ul";
+
 import { strings } from "../../assets/LocalizedStrings";
 
 interface MattersSponsoredProps {
-  mattersSponsored: MatterSponsor[];
+  mattersSponsored: FetchDataState<MatterSponsor[]>;
 }
 
 const MattersSponsored: FC<MattersSponsoredProps> = ({
   mattersSponsored,
 }: MattersSponsoredProps) => {
-  if (mattersSponsored.length === 0) {
-    return null;
-  }
+  const hiddenContent = useMemo(() => {
+    if (mattersSponsored.isLoading) {
+      return <p>Fetching legislations...</p>;
+    }
+
+    if (mattersSponsored.error) {
+      return <p>{mattersSponsored.error.message}</p>;
+    }
+    if (!mattersSponsored.data || mattersSponsored.data.length === 0) {
+      return <p>No legislations found.</p>;
+    }
+
+    return (
+      <Ul gap={8}>
+        {mattersSponsored.data.map((matterSponsored) => (
+          <li key={matterSponsored.id}>
+            <dl>
+              <dt>
+                <strong>{matterSponsored.matter?.name}</strong>
+              </dt>
+              <dd>{matterSponsored.matter?.title}</dd>
+            </dl>
+          </li>
+        ))}
+      </Ul>
+    );
+  }, [mattersSponsored]);
 
   return (
     <div style={{ marginTop: 16 }}>
@@ -28,20 +55,7 @@ const MattersSponsored: FC<MattersSponsoredProps> = ({
             {strings.legislation_sponsored}
           </H2>
         }
-        hiddenContent={
-          <Ul gap={8}>
-            {mattersSponsored.map((matterSponsored) => (
-              <li key={matterSponsored.id}>
-                <dl>
-                  <dt>
-                    <strong>{matterSponsored.matter?.name}</strong>
-                  </dt>
-                  <dd>{matterSponsored.matter?.title}</dd>
-                </dl>
-              </li>
-            ))}
-          </Ul>
-        }
+        hiddenContent={hiddenContent}
       />
     </div>
   );

--- a/src/containers/PersonContainer/PersonContainer.stories.tsx
+++ b/src/containers/PersonContainer/PersonContainer.stories.tsx
@@ -19,17 +19,22 @@ export default {
   title: "Library/Containers/Person",
 } as Meta;
 
+import { initialFetchDataState } from "../FetchDataContainer/useFetchData";
+
 const Template: Story<PersonContainerProps> = (args) => <PersonContainer {...args} />;
 
 export const personWithoutVotes = Template.bind({});
 personWithoutVotes.args = {
   person: basicPerson,
-  votes: [],
+  votes: { ...initialFetchDataState, data: [] },
   councilMemberRoles: [ten_years_councilmember],
   roles: [expired_chair, recent_chair],
-  mattersSponsored: [basicMatterSponsor, populatedMatterMatterSponsor],
-  personPictureSrc: mockImageUrl(400, 400, "Avatar Face"),
-  seatPictureSrc: mockImageUrl(1400, 800, "Electoral Seat"),
+  mattersSponsored: {
+    ...initialFetchDataState,
+    data: [basicMatterSponsor, populatedMatterMatterSponsor],
+  },
+  personPictureSrc: { ...initialFetchDataState, data: mockImageUrl(400, 400, "Avatar Face") },
+  seatPictureSrc: { ...initialFetchDataState, data: mockImageUrl(1400, 800, "Electoral Seat") },
 };
 
 export const standardLayout = Template.bind({});
@@ -37,8 +42,8 @@ standardLayout.args = {
   person: basicPerson,
   councilMemberRoles: [ten_years_councilmember],
   roles: [expired_chair, recent_chair],
-  mattersSponsored: [populatedMatterMatterSponsor],
-  votes: [vote],
-  personPictureSrc: mockImageUrl(400, 400, "Avatar Face"),
-  seatPictureSrc: mockImageUrl(1400, 800, "Electoral Seat"),
+  mattersSponsored: { ...initialFetchDataState, data: [populatedMatterMatterSponsor] },
+  votes: { ...initialFetchDataState, data: [vote] },
+  personPictureSrc: { ...initialFetchDataState, data: mockImageUrl(400, 400, "Avatar Face") },
+  seatPictureSrc: { ...initialFetchDataState, data: mockImageUrl(1400, 800, "Electoral Seat") },
 };

--- a/src/containers/PersonContainer/PersonContainer.tsx
+++ b/src/containers/PersonContainer/PersonContainer.tsx
@@ -57,7 +57,6 @@ export interface PersonContainerProps extends PersonPageData {
 }
 
 const PersonContainer = ({
-  //bodies,
   person,
   votes,
   roles,

--- a/src/containers/PersonContainer/PersonContainer.tsx
+++ b/src/containers/PersonContainer/PersonContainer.tsx
@@ -3,18 +3,15 @@ import styled from "@emotion/styled";
 
 import useDocumentTitle from "../../hooks/useDocumentTitle";
 
-import Details from "../../components/Shared/Details";
-import H2 from "../../components/Shared/H2";
-import { VotingTable } from "../../components/Tables/VotingTable";
 import ContactPerson from "./ContactPerson";
 import { CoverImage } from "./CoverImage";
 import MattersSponsored from "./MattersSponsored";
 import PersonRoles from "./PersonRoles";
+import PersonVotes from "./PersonVotes";
 import { PersonPageData } from "./types";
 
 import { fontSizes } from "../../styles/fonts";
 import { screenWidths } from "../../styles/mediaBreakpoints";
-import { strings } from "../../assets/LocalizedStrings";
 
 const Person = styled.div({
   display: "grid",
@@ -60,6 +57,7 @@ export interface PersonContainerProps extends PersonPageData {
 }
 
 const PersonContainer = ({
+  //bodies,
   person,
   votes,
   roles,
@@ -103,21 +101,7 @@ const PersonContainer = ({
       </ContactAndRoles>
       <MattersSponsored mattersSponsored={mattersSponsored} />
       <div>
-        <Details
-          hasBorderBottom={true}
-          defaultOpen={false}
-          summaryContent={
-            <H2 className="mzp-u-title-xs" isInline={true}>
-              {strings.persons_voting_record.replace("{person_name}", person.name)}
-            </H2>
-          }
-          hiddenContent={
-            <>
-              <br />
-              <VotingTable name={person.name} votesPage={votes} />{" "}
-            </>
-          }
-        />
+        <PersonVotes personName={person.name} votes={votes} />
       </div>
     </Person>
   );

--- a/src/containers/PersonContainer/PersonVotes.tsx
+++ b/src/containers/PersonContainer/PersonVotes.tsx
@@ -2,6 +2,7 @@ import React, { FC, useMemo } from "react";
 
 import Vote from "../../models/Vote";
 
+import LazyFetchDataContainer from "../FetchDataContainer/LazyFetchDataContainer";
 import { FetchDataState } from "../FetchDataContainer/useFetchData";
 import Details from "../../components/Shared/Details";
 import H2 from "../../components/Shared/H2";
@@ -16,16 +17,16 @@ interface PersonVotesProps {
 
 const PersonVotes: FC<PersonVotesProps> = ({ personName, votes }: PersonVotesProps) => {
   const hiddenContent = useMemo(() => {
-    if (votes.isLoading) {
-      return <p>Fetching votes...</p>;
-    }
-    if (votes.error) {
-      return <p>{votes.error.message}</p>;
-    }
-    if (!votes.data || votes.data.length === 0) {
-      return <p>No votes found.</p>;
-    }
-    return <VotingTable name={personName} votesPage={votes.data} />;
+    return (
+      <LazyFetchDataContainer
+        data="votes"
+        isLoading={votes.isLoading}
+        error={votes.error}
+        notFound={!votes.data || votes.data.length === 0}
+      >
+        {votes.data && <VotingTable name={personName} votesPage={votes.data} />}
+      </LazyFetchDataContainer>
+    );
   }, [personName, votes]);
   return (
     <Details

--- a/src/containers/PersonContainer/PersonVotes.tsx
+++ b/src/containers/PersonContainer/PersonVotes.tsx
@@ -1,0 +1,49 @@
+import React, { FC, useMemo } from "react";
+
+import Vote from "../../models/Vote";
+
+import { FetchDataState } from "../FetchDataContainer/useFetchData";
+import Details from "../../components/Shared/Details";
+import H2 from "../../components/Shared/H2";
+import { VotingTable } from "../../components/Tables/VotingTable";
+
+import { strings } from "../../assets/LocalizedStrings";
+
+interface PersonVotesProps {
+  personName: string;
+  votes: FetchDataState<Vote[]>;
+}
+
+const PersonVotes: FC<PersonVotesProps> = ({ personName, votes }: PersonVotesProps) => {
+  const hiddenContent = useMemo(() => {
+    if (votes.isLoading) {
+      return <p>Fetching votes...</p>;
+    }
+    if (votes.error) {
+      return <p>{votes.error.message}</p>;
+    }
+    if (!votes.data || votes.data.length === 0) {
+      return <p>No votes found.</p>;
+    }
+    return <VotingTable name={personName} votesPage={votes.data} />;
+  }, [personName, votes]);
+  return (
+    <Details
+      hasBorderBottom={true}
+      defaultOpen={false}
+      summaryContent={
+        <H2 className="mzp-u-title-xs" isInline={true}>
+          {strings.persons_voting_record.replace("{person_name}", personName)}
+        </H2>
+      }
+      hiddenContent={
+        <>
+          <br />
+          {hiddenContent}
+        </>
+      }
+    />
+  );
+};
+
+export default PersonVotes;

--- a/src/containers/PersonContainer/types.ts
+++ b/src/containers/PersonContainer/types.ts
@@ -3,19 +3,21 @@ import Person from "../../models/Person";
 import Role from "../../models/Role";
 import Vote from "../../models/Vote";
 
+import { FetchDataState } from "../FetchDataContainer/useFetchData";
+
 export interface PersonPageData {
-  /**The person */
+  /** The person */
   person: Person;
   /** Votes */
-  votes: Vote[];
+  votes: FetchDataState<Vote[]>;
   /** matters sponsored by the person */
-  mattersSponsored: MatterSponsor[];
+  mattersSponsored: FetchDataState<MatterSponsor[]>;
   /** roles held by the person with only body populated */
   roles: Role[];
   /** Councilmember roles with only seat populated */
   councilMemberRoles: Role[];
   /** Picture src of the person */
-  personPictureSrc?: string;
+  personPictureSrc: FetchDataState<string | null>;
   /** Picture of the seat for the person's recent councilmember role */
-  seatPictureSrc?: string;
+  seatPictureSrc: FetchDataState<string | null>;
 }

--- a/src/pages/EventPage/EventPage.tsx
+++ b/src/pages/EventPage/EventPage.tsx
@@ -189,7 +189,6 @@ const EventPage: FC = () => {
       sessionsDataState.error,
       eventMinutesItemsDataState.error,
       votesDataState.error,
-      sentencesDataState.error,
     ]
       .map((error) => error?.message || "")
       .filter((errorMsg) => errorMsg.length > 0);
@@ -203,7 +202,6 @@ const EventPage: FC = () => {
     sessionsDataState.error,
     eventMinutesItemsDataState.error,
     votesDataState.error,
-    sentencesDataState.error,
   ]);
 
   return (
@@ -211,7 +209,7 @@ const EventPage: FC = () => {
       {eventData && (
         <EventContainer
           {...eventData}
-          sentences={sentencesDataState.data}
+          sentences={sentencesDataState}
           searchQuery={searchQuery}
           initialSession={
             initialSession > 0 && initialSession < eventData.sessions.length ? initialSession : 0

--- a/src/pages/EventPage/EventPage.tsx
+++ b/src/pages/EventPage/EventPage.tsx
@@ -19,14 +19,9 @@ import { EventContainer } from "../../containers/EventContainer";
 import { ECSentence, ECEventMinutesItem } from "../../containers/EventContainer/types";
 import { FetchDataContainer } from "../../containers/FetchDataContainer";
 import useFetchData, {
+  initialFetchDataState,
   FetchDataActionType,
 } from "../../containers/FetchDataContainer/useFetchData";
-
-const initialFetchDataState = {
-  isLoading: false,
-  error: null,
-  hasFetchRequest: true,
-};
 
 const EventPage: FC = () => {
   // Get the id the the event, provided the route is `events/:id`

--- a/src/pages/PersonPage/PersonPage.tsx
+++ b/src/pages/PersonPage/PersonPage.tsx
@@ -1,18 +1,25 @@
-import React, { FC, useCallback } from "react";
+import React, { FC, useCallback, useMemo, useEffect } from "react";
 import { useParams } from "react-router-dom";
 
 import { useAppConfigContext } from "../../app";
-import useFetchData from "../../containers/FetchDataContainer/useFetchData";
 
-import PersonService from "../../networking/PersonService";
-import FetchDataContainer from "../../containers/FetchDataContainer/FetchDataContainer";
-import { PersonContainer } from "../../containers/PersonContainer";
-import { PersonPageData } from "../../containers/PersonContainer/types";
+import MatterSponsor from "../../models/MatterSponsor";
+import Person from "../../models/Person";
+import Role from "../../models/Role";
+import Vote from "../../models/Vote";
 
-import VoteService from "../../networking/VoteService";
-import MatterSponsorService from "../../networking/MatterSponsorService";
-import RoleService from "../../networking/RoleService";
 import FileService from "../../networking/FileService";
+import MatterSponsorService from "../../networking/MatterSponsorService";
+import PersonService from "../../networking/PersonService";
+import RoleService from "../../networking/RoleService";
+import VoteService from "../../networking/VoteService";
+
+import FetchDataContainer from "../../containers/FetchDataContainer/FetchDataContainer";
+import useFetchData, {
+  FetchDataActionType,
+  initialFetchDataState,
+} from "../../containers/FetchDataContainer/useFetchData";
+import { PersonContainer } from "../../containers/PersonContainer";
 
 const PersonPage: FC = () => {
   // Get the id the person, provided the route is `persons/:id`
@@ -20,67 +27,143 @@ const PersonPage: FC = () => {
   // Get the app config context
   const { firebaseConfig } = useAppConfigContext();
 
-  const fetchPersonData = useCallback(async () => {
+  const fetchPerson = useCallback(async () => {
     const personService = new PersonService(firebaseConfig);
-    const voteService = new VoteService(firebaseConfig);
-    const matterSponsorService = new MatterSponsorService(firebaseConfig);
-    const roleService = new RoleService(firebaseConfig);
-    const fileService = new FileService(firebaseConfig);
-    const { networkService } = fileService;
-
-    const [person, votes, mattersSponsored, councilMemberRoles, roles] = await Promise.all([
-      personService.getPersonById(id),
-      voteService.getFullyPopulatedVotesByPersonId(id),
-      matterSponsorService.getMattersSponsoredByPersonId(id),
-      roleService.getCouncilMemberRolesByPersonId(id),
-      roleService.getPopulatedRolesByPersonId(id),
-    ]);
-
-    const pictureSrcPromises: Promise<string | undefined>[] = [
-      person.picture
-        ? networkService.getDownloadUrl(person.picture.uri)
-        : Promise.resolve(undefined),
-    ];
-
-    if (
-      councilMemberRoles.length > 0 &&
-      councilMemberRoles[0].seat &&
-      councilMemberRoles[0].seat.image_ref
-    ) {
-      const seatImage = await fileService.getFileById(councilMemberRoles[0].seat.image_ref);
-      pictureSrcPromises.push(networkService.getDownloadUrl(seatImage.uri));
-    } else {
-      pictureSrcPromises.push(Promise.resolve(undefined));
-    }
-
-    const [personPictureSrc, seatPictureSrc] = await Promise.all(pictureSrcPromises);
-
-    const payload: PersonPageData = {
-      person,
-      votes,
-      mattersSponsored,
-      roles,
-      personPictureSrc,
-      seatPictureSrc,
-      councilMemberRoles,
-    };
-
-    return payload;
+    const person = await personService.getPersonById(id);
+    return Promise.resolve(person);
   }, [id, firebaseConfig]);
-
-  // Initialize the state of fetching the person's data
-  const { state: personDataState } = useFetchData<PersonPageData>(
-    {
-      isLoading: false,
-      error: null,
-      hasFetchRequest: true,
-    },
-    fetchPersonData
+  const { state: personDataState } = useFetchData<Person>(
+    { ...initialFetchDataState },
+    fetchPerson
   );
 
+  const fetchPersonPicture = useCallback(async () => {
+    const fileService = new FileService(firebaseConfig);
+    const { networkService } = fileService;
+    if (personDataState.data?.picture) {
+      const personPictureSrc = await networkService.getDownloadUrl(
+        personDataState.data.picture.uri
+      );
+      return Promise.resolve(personPictureSrc);
+    }
+    return Promise.resolve(null);
+  }, [personDataState.data, firebaseConfig]);
+  const { state: personPictureDataState, dispatch: personPictureDataDispatch } = useFetchData<
+    string | null
+  >({ ...initialFetchDataState, hasFetchRequest: false }, fetchPersonPicture);
+
+  useEffect(() => {
+    if (personDataState.data) {
+      // fetch the person picture when the person is fetched
+      personPictureDataDispatch({ type: FetchDataActionType.FETCH });
+    }
+  }, [personDataState.data, personPictureDataDispatch]);
+
+  const fetchCouncilmemberRoles = useCallback(async () => {
+    const roleService = new RoleService(firebaseConfig);
+    const roles = await roleService.getCouncilMemberRolesByPersonId(id);
+    return Promise.resolve(roles);
+  }, [id, firebaseConfig]);
+  const { state: councilmemberRolesDataState } = useFetchData<Role[]>(
+    { ...initialFetchDataState },
+    fetchCouncilmemberRoles
+  );
+
+  const fetchSeatPicture = useCallback(async () => {
+    const fileService = new FileService(firebaseConfig);
+    const { networkService } = fileService;
+    if (
+      councilmemberRolesDataState.data &&
+      councilmemberRolesDataState.data.length > 0 &&
+      councilmemberRolesDataState.data[0].seat &&
+      councilmemberRolesDataState.data[0].seat.image_ref
+    ) {
+      const seatImage = await fileService.getFileById(
+        councilmemberRolesDataState.data[0].seat.image_ref
+      );
+      const seatImageSrc = await networkService.getDownloadUrl(seatImage.uri);
+      return Promise.resolve(seatImageSrc);
+    }
+    return Promise.resolve(null);
+  }, [councilmemberRolesDataState.data, firebaseConfig]);
+  const { state: seatPictureDataState, dispatch: seatPictureDataDispatch } = useFetchData<
+    string | null
+  >({ ...initialFetchDataState, hasFetchRequest: false }, fetchSeatPicture);
+  useEffect(() => {
+    if (councilmemberRolesDataState.data) {
+      // fetch the seat picture when the council member roles are fetched
+      seatPictureDataDispatch({ type: FetchDataActionType.FETCH });
+    }
+  }, [councilmemberRolesDataState.data, seatPictureDataDispatch]);
+
+  const fetchRoles = useCallback(async () => {
+    const roleService = new RoleService(firebaseConfig);
+    const roles = await roleService.getPopulatedRolesByPersonId(id);
+    return Promise.resolve(roles);
+  }, [id, firebaseConfig]);
+  const { state: rolesDataState } = useFetchData<Role[]>({ ...initialFetchDataState }, fetchRoles);
+
+  const fetchMatterSponsored = useCallback(async () => {
+    const matterSponsorService = new MatterSponsorService(firebaseConfig);
+    const mattersSponsored = await matterSponsorService.getMattersSponsoredByPersonId(id);
+    return Promise.resolve(mattersSponsored);
+  }, [id, firebaseConfig]);
+  const { state: mattersSponsoredDataState } = useFetchData<MatterSponsor[]>(
+    { ...initialFetchDataState },
+    fetchMatterSponsored
+  );
+
+  const fetchVotes = useCallback(async () => {
+    const voteService = new VoteService(firebaseConfig);
+    const votes = await voteService.getFullyPopulatedVotesByPersonId(id);
+    return Promise.resolve(votes);
+  }, [id, firebaseConfig]);
+  const { state: votesDataState } = useFetchData<Vote[]>({ ...initialFetchDataState }, fetchVotes);
+
+  const isFetchingPersonData = useMemo(() => {
+    return (
+      personDataState.isLoading || councilmemberRolesDataState.isLoading || rolesDataState.isLoading
+    );
+  }, [personDataState.isLoading, councilmemberRolesDataState.isLoading, rolesDataState.isLoading]);
+
+  const personData = useMemo(() => {
+    if (!personDataState.data || !councilmemberRolesDataState.data || !rolesDataState.data) {
+      // not all fetch requests has completed
+      return undefined;
+    }
+    return {
+      person: personDataState.data,
+      councilMemberRoles: councilmemberRolesDataState.data,
+      roles: rolesDataState.data,
+    };
+  }, [personDataState.data, councilmemberRolesDataState.data, rolesDataState.data]);
+
+  const fetchPersonDataError = useMemo(() => {
+    const errorMsgs = [
+      personDataState.error,
+      councilmemberRolesDataState.error,
+      rolesDataState.error,
+    ]
+      .map((error) => error?.message || "")
+      .filter((errorMsg) => errorMsg.length > 0);
+    if (errorMsgs.length > 0) {
+      // create one error from all the error msgs
+      return new Error(errorMsgs.join("\n"));
+    }
+    return null;
+  }, [personDataState.error, councilmemberRolesDataState.error, rolesDataState.error]);
+
   return (
-    <FetchDataContainer isLoading={personDataState.isLoading} error={personDataState.error}>
-      {personDataState.data && <PersonContainer {...personDataState.data} />}
+    <FetchDataContainer isLoading={isFetchingPersonData} error={fetchPersonDataError}>
+      {personData && (
+        <PersonContainer
+          {...personData}
+          personPictureSrc={personPictureDataState}
+          seatPictureSrc={seatPictureDataState}
+          mattersSponsored={mattersSponsoredDataState}
+          votes={votesDataState}
+        />
+      )}
     </FetchDataContainer>
   );
 };

--- a/src/stories/model-mocks/sentence.ts
+++ b/src/stories/model-mocks/sentence.ts
@@ -1,0 +1,18 @@
+import { ECSentence } from "../../containers/EventContainer/types";
+
+export function mockSentences(numSessions: number, numSentences: number) {
+  const sentences: ECSentence[] = [];
+  for (let sessionIndex = 0; sessionIndex < numSessions; sessionIndex++) {
+    for (let sentenceIndex = 0; sentenceIndex < numSentences; sentenceIndex++) {
+      sentences.push({
+        session_index: sessionIndex,
+        index: sessionIndex * numSentences + sentenceIndex,
+        start_time: sentenceIndex,
+        text: `This is a sentence ${sessionIndex * numSentences + sentenceIndex}.`,
+        speaker_index: sentenceIndex,
+        speaker_name: `Speaker ${sentenceIndex}`,
+      });
+    }
+  }
+  return sentences;
+}


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  ⚠️⚠️ Please do the following before submitting: ⚠️⚠️

  - Read the CONTRIBUTING.md guide and make sure you've followed all the steps given.
  - Ensure that the code is up-to-date with the `main` branch.
  - Provide or update documentation for any feature added by your pull request.
  - Provide relevant tests for your feature or bug fix.

  ❗️ Also: ❗️

  Please name your pull request {development-type}/{short-description}.
  For example: feature/read-tiff-files
-->

### Link to Relevant Issue

This pull request resolves #194 #166 

### Description of Changes

_Include a description of the proposed changes._
Reduce the "time to interactivity" of the person page by allowing it to render before
- the person and seat pictures are loaded (the real culprit of our current and slow person page)
- the matter sponsored by a person are fetched
- the votes of the person are fetched

The approach is the same as before for the event page. Separate each call to the DB into it's own `useFetchData` call, then decide which data is needed for the page to render. For the person page, it's the `person` and their `roles`.

I added a little component for displaying the "loading" skeleton (sort of a placeholder UI) for pictures so that the layout of the page doesn't change when the pictures are loaded.

Created `LazyFetchDataContainer`, a non-blocking version of `FetchDataContainer` to handle the rendering logic -- is it fetching data, is there an error, and to display the data when it is fetched. Although these two containers look similar, code-wise, and could be combined into one, I decided to keep them separated because the rendering logic for pages and smaller components could diverge in the future.

### Link to Forked Storybook Site

_If component changes (especially visual changes) are contained in this PR, we ask that you provide a link to a publicly viewable version of the Storybook docs site, so PR reviewers can see your changes without having to install and view your code locally._

_Please see `CONTRIBUTING.md` for directions on how this can be done._
https://tohuynh.github.io/cdp-frontend/#/people/6410ce724625
