### PR TITLE
fix/vice-chair-localization

### DIFF
--- a/src/assets/LocalizedStrings.tsx
+++ b/src/assets/LocalizedStrings.tsx
@@ -93,7 +93,7 @@ export interface MasterStringsList extends LocalizedStringsMethods {
   alternate: string;
   councilmember: string;
   member: string;
-  councilpresident: string;
+  council_president: string;
   vice_chair: string;
   active: string;
   inactive: string;

--- a/src/assets/strings/de.ts
+++ b/src/assets/strings/de.ts
@@ -82,7 +82,7 @@ const de = {
   alternate: "Wechseln",
   councilmember: "Stadtrat/in",
   member: "Mitglied",
-  councilpresident: "Präsident des Rates",
+  council_president: "Präsident des Rates",
   vice_chair: "Stellvertretender Vorsitzender",
   active: "aktiv",
   inactive: "inaktiv",

--- a/src/assets/strings/en.ts
+++ b/src/assets/strings/en.ts
@@ -81,7 +81,7 @@ const en = {
   alternate: "Alternate",
   councilmember: "Councilmember",
   member: "Member",
-  councilpresident: "Council President",
+  council_president: "Council President",
   vice_chair: "Vice Chair",
   active: "active",
   inactive: "inactive",

--- a/src/assets/strings/es.ts
+++ b/src/assets/strings/es.ts
@@ -81,7 +81,7 @@ const es = {
   alternate: "Alterno/a",
   councilmember: "Concejal/a",
   member: "Miembro",
-  councilpresident: "Presidente/a del Consejo",
+  council_president: "Presidente/a del Consejo",
   vice_chair: "Vicepresidente/a",
   active: "activo/a",
   inactive: "inactivo/a",

--- a/src/containers/PersonContainer/PersonRoles.tsx
+++ b/src/containers/PersonContainer/PersonRoles.tsx
@@ -32,7 +32,7 @@ const CommitteeMembership: FC<CommitteeMembershipProps> = ({
         <Ul gap={4}>
           {roles.map((role) => (
             <li key={role.id}>
-              <strong>{`${strings[role.title.toLowerCase()]}: `}</strong>
+              <strong>{`${strings[role.title.toLowerCase().replace(" ", "_")]}: `}</strong>
               <Link
                 to={{
                   pathname: "/events",
@@ -99,7 +99,7 @@ const PersonRoles: FC<PersonRolesProps> = ({ councilMemberRoles, allRoles }: Per
                 defaultOpen={isCurrentRole}
                 summaryContent={
                   <span style={{ fontSize: fontSizes.font_size_6 }}>
-                    <strong>{`${role.title}: `}</strong>{" "}
+                    <strong>{`${strings[role.title.toLowerCase().replace(" ", "_")]}: `}</strong>{" "}
                     {`${role.seat?.name} // ${
                       role.seat?.electoral_area
                     } (${role.start_datetime.toLocaleDateString()} - ${


### PR DESCRIPTION
Localize council member/president in `PersonRoles`

<!--
  Thank you for submitting a pull request!

  ⚠️⚠️ Please do the following before submitting: ⚠️⚠️

  - Read the CONTRIBUTING.md guide and make sure you've followed all the steps given.
  - Ensure that the code is up-to-date with the `main` branch.
  - Provide or update documentation for any feature added by your pull request.
  - Provide relevant tests for your feature or bug fix.

  ❗️ Also: ❗️

  Please name your pull request {development-type}/{short-description}.
  For example: feature/read-tiff-files
-->

### Link to Relevant Issue

This pull request resolves #

### Description of Changes

_Include a description of the proposed changes._
Vice chair roles on the person page were rendered as `undefined`. The fix was just to account for `Vice Chair`, which needed to be converted to `vice_chair` in order to be localized.
Also localized the council member/council president role.

### Link to Forked Storybook Site

_If component changes (especially visual changes) are contained in this PR, we ask that you provide a link to a publicly viewable version of the Storybook docs site, so PR reviewers can see your changes without having to install and view your code locally._

_Please see `CONTRIBUTING.md` for directions on how this can be done._
