### PR TITLE
feature/allow-youtube-links

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20226,6 +20226,14 @@
         "global": "^4.3.1"
       }
     },
+    "videojs-youtube": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/videojs-youtube/-/videojs-youtube-2.6.1.tgz",
+      "integrity": "sha512-qvwrkgXixbX8xzdkBa7o5r9KUITRISAy4bbyrpBgub3m0mhwz6WLXDIwJZ6/w4Z/JijWjLQqlg8W1jYhCEgHZw==",
+      "requires": {
+        "video.js": "^5.6.0 || ^6.2.8 || ^7.0.2"
+      }
+    },
     "vite": {
       "version": "2.7.9",
       "resolved": "https://registry.npmjs.org/vite/-/vite-2.7.9.tgz",

--- a/package.json
+++ b/package.json
@@ -117,7 +117,8 @@
     "semantic-ui-react": "^2.0.3",
     "stemr": "^1.0.0",
     "stopword": "^1.0.11",
-    "video.js": "^7.14.3"
+    "video.js": "^7.14.3",
+    "videojs-youtube": "^2.6.1"
   },
   "repository": {
     "type": "git",

--- a/src/components/Details/EventVideo/EventVideo.tsx
+++ b/src/components/Details/EventVideo/EventVideo.tsx
@@ -1,8 +1,10 @@
 import React, { FC, RefObject, useCallback, useEffect, useImperativeHandle, useRef } from "react";
 import videojs, { VideoJsPlayer } from "video.js";
+import "videojs-youtube/dist/Youtube.min.js";
 
 import { useLanguageConfigContext } from "../../../app/LanguageConfigContext";
 import { ShareVideo } from "./ShareVideo";
+import { getSource } from "./utils";
 
 import "video.js/dist/video-js.css";
 import "./vjs-theme-cdp.css";
@@ -96,7 +98,8 @@ const EventVideo: FC<EventVideoProps> = ({
           language: language,
           playbackRates: [2, 1.5, 1, 0.75, 0.5],
           responsive: true,
-          sources: [{ src: uri }],
+          techOrder: ["youtube", "html5"],
+          sources: [getSource(uri)],
           userActions: {
             hotkeys: (event) => {
               if (event.which === KeyBoardKey.K || event.which === KeyBoardKey.SPACE) {

--- a/src/components/Details/EventVideo/constants.ts
+++ b/src/components/Details/EventVideo/constants.ts
@@ -1,0 +1,5 @@
+export enum VideoMediaType {
+  mp4 = "mp4",
+  webm = "webm",
+  youtube = "youtube",
+}

--- a/src/components/Details/EventVideo/utils.ts
+++ b/src/components/Details/EventVideo/utils.ts
@@ -1,0 +1,29 @@
+import { VideoMediaType } from "./constants";
+
+export function getMediaTypeFromUri(uri: string) {
+  let type: string | undefined;
+  if (uri.match(/youtu?.be/)) {
+    type = VideoMediaType.youtube;
+  } else {
+    // uri must have media type webm or mp4
+    const matches = uri.match(new RegExp(`(${VideoMediaType.webm}|${VideoMediaType.mp4})$`));
+    if (matches) {
+      type = matches[0];
+    }
+  }
+  return type;
+}
+
+interface Source {
+  src: string;
+  type?: string;
+}
+
+export function getSource(uri: string) {
+  const mediaType = getMediaTypeFromUri(uri);
+  const source: Source = { src: uri };
+  if (mediaType) {
+    source.type = `video/${mediaType}`;
+  }
+  return source;
+}


### PR DESCRIPTION
Allow the portland deployment to play youtube links

- installed videojs-youtube
- added `getSource` helper to infer the media type from `uri` of the video