### PR TITLE
component/legislation-timeline

### DIFF
--- a/src/assets/LocalizedStrings.tsx
+++ b/src/assets/LocalizedStrings.tsx
@@ -98,6 +98,7 @@ export interface MasterStringsList extends LocalizedStringsMethods {
   active: string;
   inactive: string;
   latest_vote: string;
+  history: string;
 }
 
 // Note: Add languages to video.js in /src/pages/EventPage/utils when adding new languages

--- a/src/assets/strings/de.ts
+++ b/src/assets/strings/de.ts
@@ -87,6 +87,7 @@ const de = {
   active: "aktiv",
   inactive: "inaktiv",
   latest_vote: "Letzte Abstimmung",
+  history: "Geschichte",
 };
 
 export default de;

--- a/src/assets/strings/en.ts
+++ b/src/assets/strings/en.ts
@@ -86,6 +86,7 @@ const en = {
   active: "active",
   inactive: "inactive",
   latest_vote: "Latest Vote",
+  history: "History",
 };
 
 export default en;

--- a/src/assets/strings/es.ts
+++ b/src/assets/strings/es.ts
@@ -86,6 +86,7 @@ const es = {
   active: "activo/a",
   inactive: "inactivo/a",
   latest_vote: "Último Voto",
+  history: "Historia",
 };
 
 export default es;

--- a/src/components/Details/Legislation/LegislationHistory.stories.tsx
+++ b/src/components/Details/Legislation/LegislationHistory.stories.tsx
@@ -1,0 +1,28 @@
+import React from "react";
+
+import { Story, Meta } from "@storybook/react";
+
+import { LegislationHistoryProps, LegislationHistory } from "./LegislationHistory";
+import {
+  basicFailEventMinutesItem,
+  basicPassEventMinutesItem,
+  nonVotingEventMinutesItem,
+} from "../../../stories/model-mocks/eventMinutesItem";
+
+export default {
+  component: LegislationHistory,
+  title: "Library/Details/Legislation/History",
+} as Meta;
+
+const Template: Story<LegislationHistoryProps> = (args) => <LegislationHistory {...args} />;
+
+export const history = Template.bind({});
+history.args = {
+  eventMinutesItems: [
+    basicFailEventMinutesItem,
+    nonVotingEventMinutesItem,
+    basicPassEventMinutesItem,
+    basicFailEventMinutesItem,
+    nonVotingEventMinutesItem,
+  ],
+};

--- a/src/components/Details/Legislation/LegislationHistory.tsx
+++ b/src/components/Details/Legislation/LegislationHistory.tsx
@@ -32,23 +32,13 @@ const LegislationHistory: FC<LegislationHistoryProps> = ({
         hiddenContent={
           <ColumnMakingContainer>
             {eventMinutesItems.map((eventMinutesItem, index) => {
-              if (index === eventMinutesItems.length - 1) {
-                return (
-                  <LegislativeHistoryNode
-                    isLastIndex={true}
-                    key={`leg_hist_node_${eventMinutesItem.id}_${index}`}
-                    eventMinutesItem={eventMinutesItem}
-                  />
-                );
-              } else {
-                return (
-                  <LegislativeHistoryNode
-                    isLastIndex={false}
-                    key={`leg_hist_node_${eventMinutesItem.id}_${index}`}
-                    eventMinutesItem={eventMinutesItem}
-                  />
-                );
-              }
+              return (
+                <LegislativeHistoryNode
+                  isLastIndex={index === eventMinutesItems.length - 1}
+                  key={`leg_hist_node_${eventMinutesItem.id}_${index}`}
+                  eventMinutesItem={eventMinutesItem}
+                />
+              );
             })}
           </ColumnMakingContainer>
         }

--- a/src/components/Details/Legislation/LegislationHistory.tsx
+++ b/src/components/Details/Legislation/LegislationHistory.tsx
@@ -6,6 +6,11 @@ import Details from "../../Shared/Details";
 import { LegislativeHistoryNode } from "./LegislativeHistoryNode";
 import { strings } from "../../../assets/LocalizedStrings";
 
+import styled from "@emotion/styled";
+
+const SpacerContainer = styled.div({ marginTop: 16 });
+const ColumnMakingContainer = styled.div({ display: "flex", flexDirection: "column" });
+
 export interface LegislationHistoryProps {
   /** the timeline of a matter as represented by an ordered series of EventMinutesItem  */
   eventMinutesItems: EventMinutesItem[];
@@ -15,17 +20,17 @@ const LegislationHistory: FC<LegislationHistoryProps> = ({
   eventMinutesItems,
 }: LegislationHistoryProps) => {
   return (
-    <div style={{ marginTop: 16 }}>
+    <SpacerContainer>
       <Details
         hasBorderBottom={true}
         defaultOpen={false}
         summaryContent={
           <H2 className="mzp-u-title-xs" isInline={true}>
-            History
+            {strings.history}
           </H2>
         }
         hiddenContent={
-          <div style={{ display: "flex", flexDirection: "column" }}>
+          <ColumnMakingContainer>
             {eventMinutesItems.map((eventMinutesItem, index) => {
               if (index === eventMinutesItems.length - 1) {
                 return (
@@ -45,10 +50,10 @@ const LegislationHistory: FC<LegislationHistoryProps> = ({
                 );
               }
             })}
-          </div>
+          </ColumnMakingContainer>
         }
       />
-    </div>
+    </SpacerContainer>
   );
 };
 

--- a/src/components/Details/Legislation/LegislationHistory.tsx
+++ b/src/components/Details/Legislation/LegislationHistory.tsx
@@ -1,0 +1,55 @@
+import React, { FC } from "react";
+
+import EventMinutesItem from "../../../models/EventMinutesItem";
+import H2 from "../../Shared/H2";
+import Details from "../../Shared/Details";
+import { LegislativeHistoryNode } from "./LegislativeHistoryNode";
+import { strings } from "../../../assets/LocalizedStrings";
+
+export interface LegislationHistoryProps {
+  /** the timeline of a matter as represented by an ordered series of EventMinutesItem  */
+  eventMinutesItems: EventMinutesItem[];
+}
+
+const LegislationHistory: FC<LegislationHistoryProps> = ({
+  eventMinutesItems,
+}: LegislationHistoryProps) => {
+  return (
+    <div style={{ marginTop: 16 }}>
+      <Details
+        hasBorderBottom={true}
+        defaultOpen={false}
+        summaryContent={
+          <H2 className="mzp-u-title-xs" isInline={true}>
+            History
+          </H2>
+        }
+        hiddenContent={
+          <div style={{ display: "flex", flexDirection: "column" }}>
+            {eventMinutesItems.map((eventMinutesItem, index) => {
+              if (index === eventMinutesItems.length - 1) {
+                return (
+                  <LegislativeHistoryNode
+                    isLastIndex={true}
+                    key={`leg_hist_node_${eventMinutesItem.id}_${index}`}
+                    eventMinutesItem={eventMinutesItem}
+                  />
+                );
+              } else {
+                return (
+                  <LegislativeHistoryNode
+                    isLastIndex={false}
+                    key={`leg_hist_node_${eventMinutesItem.id}_${index}`}
+                    eventMinutesItem={eventMinutesItem}
+                  />
+                );
+              }
+            })}
+          </div>
+        }
+      />
+    </div>
+  );
+};
+
+export { LegislationHistory };

--- a/src/components/Details/Legislation/LegislationLatestVote.tsx
+++ b/src/components/Details/Legislation/LegislationLatestVote.tsx
@@ -1,13 +1,10 @@
-import React, { FC, ReactNode } from "react";
+import React, { FC } from "react";
 
 import Vote from "../../../models/Vote";
-import VoteBar from "./VoteBar";
 import H2 from "../../Shared/H2";
 import Details from "../../Shared/Details";
-import { getVoteDistribution } from "../../Shared/util/voteDistribution";
 import { strings } from "../../../assets/LocalizedStrings";
-
-const VOTE_BAR_HEIGHT = 16;
+import { VoteDistributionGraphic } from "./VoteDistributionGraphic";
 export interface LegislationLatestVoteProps {
   /** votes on the matter */
   votes: Vote[];
@@ -16,44 +13,6 @@ export interface LegislationLatestVoteProps {
 const LegislationLatestVote: FC<LegislationLatestVoteProps> = ({
   votes,
 }: LegislationLatestVoteProps) => {
-  const { inFavor, against, abstained } = getVoteDistribution(votes);
-  const votesForLabel: string = strings.number_approved.replace("{number}", `${inFavor.length}`);
-  const votesAgainstLabel: string = strings.number_rejected.replace(
-    "{number}",
-    `${against.length}`
-  );
-  const votesAbstainedLabel: string = strings.number_non_voting.replace(
-    "{number}",
-    `${abstained.length}`
-  );
-
-  const voteBars: ReactNode[] = [
-    <VoteBar
-      key={"inFavorVoteBar"}
-      statusColor={"cdp-bg-acceptance-green"}
-      votes={inFavor}
-      percentage={(inFavor.length / votes.length) * 100}
-      height={VOTE_BAR_HEIGHT}
-      label={votesForLabel}
-    />,
-    <VoteBar
-      key={"againstVoteBar"}
-      statusColor={"cdp-bg-rejected-red"}
-      votes={against}
-      percentage={(against.length / votes.length) * 100}
-      height={VOTE_BAR_HEIGHT}
-      label={votesAgainstLabel}
-    />,
-    <VoteBar
-      key={"abstainedVoteBar"}
-      statusColor={"cdp-bg-light-purple"}
-      votes={abstained}
-      percentage={(abstained.length / votes.length) * 100}
-      height={VOTE_BAR_HEIGHT}
-      label={votesAbstainedLabel}
-    />,
-  ];
-
   return (
     <div style={{ marginTop: 16 }}>
       <Details
@@ -64,7 +23,7 @@ const LegislationLatestVote: FC<LegislationLatestVoteProps> = ({
             {strings.latest_vote}
           </H2>
         }
-        hiddenContent={<div style={{ display: "flex", flexDirection: "column" }}>{voteBars}</div>}
+        hiddenContent={<VoteDistributionGraphic votes={votes} />}
       />
     </div>
   );

--- a/src/components/Details/Legislation/LegislativeHistoryNode.tsx
+++ b/src/components/Details/Legislation/LegislativeHistoryNode.tsx
@@ -1,4 +1,5 @@
 import React, { FC, useCallback, useState, useRef } from "react";
+import { Link } from "react-router-dom";
 import { useAppConfigContext, useLanguageConfigContext } from "../../../app";
 
 import VoteService from "../../../networking/VoteService";
@@ -15,7 +16,8 @@ import useFetchData, {
 import { FetchDataContainer } from "../../../containers/FetchDataContainer";
 
 import styled from "@emotion/styled";
-
+import Details from "../../Shared/Details";
+import { strings } from "../../../assets/LocalizedStrings";
 export interface LegislativeHistoryNodeProps {
   /** event in the matter's timeline */
   eventMinutesItem: EventMinutesItem;
@@ -30,8 +32,13 @@ const EVENT_MINUTES_ITEM_DECISION_COLOR = {
 const MARGIN = 12;
 
 const ReferenceFrame = styled.div({ position: "relative" });
-const ExpandingContainer = styled.div({ margin: MARGIN });
-const DateContainer = styled.div({ marginLeft: MARGIN });
+const ExpandingContainer = styled.div({
+  margin: MARGIN,
+  display: "flex",
+  flexDirection: "row",
+  gap: 32,
+});
+const TextContainer = styled.div({ flex: 1 });
 const VotingGraphicContainer = styled.div({ flex: 1, marginTop: MARGIN, marginLeft: MARGIN * 2 });
 const TitleBox = styled.div({ display: "flex", flexDirection: "row", cursor: "pointer" });
 
@@ -79,25 +86,31 @@ const LegislativeHistoryNode: FC<LegislativeHistoryNodeProps> = ({
   );
 
   return (
-    <ReferenceFrame ref={divRef}>
+    <ReferenceFrame>
       <ExpandingContainer>
-        <TitleBox
-          onClick={() => {
-            setExpanded((prev) => !prev);
-          }}
-        >
-          <Dot className={dotColor} />
-          <DateContainer>{localizedDateString}</DateContainer>
-        </TitleBox>
-        {expanded && (
-          <FetchDataContainer isLoading={votesDataState.isLoading} error={votesDataState.error}>
-            {votesDataState.data && votesDataState.data.length > 0 && (
-              <VotingGraphicContainer>
-                <VoteDistributionGraphic votes={votesDataState.data} />
-              </VotingGraphicContainer>
-            )}
-          </FetchDataContainer>
-        )}
+        <Dot className={dotColor} />
+        <TextContainer>
+          <Link to={`/events/${eventMinutesItem.event?.id}`}>{localizedDateString}</Link>
+          {votesDataState.data && votesDataState.data.length > 0 && (
+            <Details
+              summaryContent={strings.votes}
+              hiddenContent={
+                <FetchDataContainer
+                  isLoading={votesDataState.isLoading}
+                  error={votesDataState.error}
+                >
+                  {votesDataState.data && votesDataState.data.length > 0 && (
+                    <VotingGraphicContainer>
+                      <VoteDistributionGraphic votes={votesDataState.data} />
+                    </VotingGraphicContainer>
+                  )}
+                </FetchDataContainer>
+              }
+              defaultOpen={false}
+              hasBorderBottom={false}
+            />
+          )}
+        </TextContainer>
       </ExpandingContainer>
       {!isLastIndex && <ConnectBar />}
     </ReferenceFrame>

--- a/src/components/Details/Legislation/LegislativeHistoryNode.tsx
+++ b/src/components/Details/Legislation/LegislativeHistoryNode.tsx
@@ -51,10 +51,10 @@ const LegislativeHistoryNode: FC<LegislativeHistoryNodeProps> = ({
   });
   const TextContainer = styled.div({ flex: 1 });
   const SummaryInfo = styled.div({ display: "flex", flexDirection: "row" });
-  const VotingGraphicContainer = styled.div<{ marginLeft: number }>((props) => ({
+  const VotingGraphicContainer = styled.div(() => ({
     flex: 1,
     marginTop: MARGIN,
-    marginLeft: props.marginLeft,
+    marginLeft: isMobile ? 0 : MARGIN * 2,
   }));
 
   const ConnectBar = styled.div({
@@ -124,7 +124,7 @@ const LegislativeHistoryNode: FC<LegislativeHistoryNodeProps> = ({
             )}
           </SummaryInfo>
           <LazyFetchDataContainer
-            data="legislativeHistoryNodeDataState"
+            data="votes and documents associated with this event"
             isLoading={votesDataState.isLoading}
             error={votesDataState.error}
             notFound={!votesDataState.data}
@@ -133,7 +133,7 @@ const LegislativeHistoryNode: FC<LegislativeHistoryNodeProps> = ({
               <Details
                 summaryContent={strings.votes}
                 hiddenContent={
-                  <VotingGraphicContainer marginLeft={isMobile ? 0 : MARGIN * 2}>
+                  <VotingGraphicContainer>
                     <VoteDistributionGraphic votes={votesDataState.data?.votes} />
                   </VotingGraphicContainer>
                 }

--- a/src/components/Details/Legislation/LegislativeHistoryNode.tsx
+++ b/src/components/Details/Legislation/LegislativeHistoryNode.tsx
@@ -1,0 +1,128 @@
+import React, { FC, useCallback, useState, useRef, useLayoutEffect } from "react";
+import useFetchData, {
+  initialFetchDataState,
+} from "../../../containers/FetchDataContainer/useFetchData";
+import { useAppConfigContext, useLanguageConfigContext } from "../../../app";
+
+import VoteService from "../../../networking/VoteService";
+
+import Vote from "../../../models/Vote";
+import EventMinutesItem from "../../../models/EventMinutesItem";
+
+import { FetchDataContainer } from "../../../containers/FetchDataContainer";
+import { VoteDistributionGraphic } from "./VoteDistributionGraphic";
+import { Dot, DOT_SIZE } from "../../Shared/Dot";
+
+import styled from "@emotion/styled";
+
+import { EVENT_MINUTES_ITEM_DECISION } from "../../../models/constants";
+
+const MARGIN = 12;
+
+export interface LegislativeHistoryNodeProps {
+  /** event in the matter's timeline */
+  eventMinutesItem: EventMinutesItem;
+  /** this node is the last index on the timeline */
+  isLastIndex: boolean;
+}
+
+const EVENT_MINUTES_ITEM_DECISION_COLOR = {
+  [EVENT_MINUTES_ITEM_DECISION.PASSED]: "cdp-bg-acceptance-green",
+  [EVENT_MINUTES_ITEM_DECISION.FAILED]: "cdp-bg-rejected-red",
+};
+
+const ConnectBar = styled.div<{ height: number; top: number; left: number }>((props) => ({
+  position: "absolute",
+  top: props.top + DOT_SIZE,
+  left: props.left + DOT_SIZE / 2,
+  height: props.height + MARGIN,
+  width: 2,
+  zIndex: 0,
+  backgroundColor: "grey",
+}));
+
+const LegislativeHistoryNode: FC<LegislativeHistoryNodeProps> = ({
+  eventMinutesItem,
+  isLastIndex,
+}: LegislativeHistoryNodeProps) => {
+  const { firebaseConfig } = useAppConfigContext();
+  const { language } = useLanguageConfigContext();
+  const [expanded, setExpanded] = useState(false);
+  const [connectionLineValues, setConnectionLineValues] = useState({
+    top: 0,
+    left: 0,
+    height: 0,
+  });
+
+  const divRef = useRef<HTMLDivElement>(null);
+  const dotColor = eventMinutesItem.decision
+    ? EVENT_MINUTES_ITEM_DECISION_COLOR[eventMinutesItem.decision]
+    : "cdp-bg-neutral-grey";
+
+  const fetchVotesForEvent = useCallback(async () => {
+    if (eventMinutesItem.decision) {
+      const votesService = new VoteService(firebaseConfig);
+      const votes = await votesService.getVotesByEventMinutesItemId(eventMinutesItem.id);
+      return Promise.resolve(votes);
+    } else {
+      return Promise.resolve([]);
+    }
+  }, [eventMinutesItem.id, firebaseConfig]);
+
+  const { state: votesDataState } = useFetchData<Vote[]>(
+    { ...initialFetchDataState },
+    fetchVotesForEvent
+  );
+
+  useLayoutEffect(() => {
+    if (divRef.current?.getBoundingClientRect()) {
+      setConnectionLineValues((prevValues) => {
+        return {
+          ...prevValues,
+          ["top"]: divRef.current?.getBoundingClientRect().top || 0,
+          ["height"]: divRef.current?.getBoundingClientRect().height || 0,
+          ["left"]: divRef.current?.getBoundingClientRect().left || 0,
+        };
+      });
+    }
+  }, [expanded]);
+
+  return (
+    <div>
+      <div
+        ref={divRef}
+        style={{ display: "flex", flexDirection: "row", margin: 12, cursor: "pointer" }}
+        onClick={() => {
+          setExpanded(!expanded);
+        }}
+      >
+        <Dot className={dotColor} />
+        <div style={{ marginLeft: 12 }}>
+          {eventMinutesItem.event?.event_datetime.toLocaleDateString(language, {
+            month: "long",
+            day: "numeric",
+            year: "numeric",
+          })}
+        </div>
+        {expanded && (
+          <FetchDataContainer isLoading={votesDataState.isLoading} error={votesDataState.error}>
+            {votesDataState.data && votesDataState.data.length > 0 && (
+              <div style={{ flex: 1, marginTop: 12 }}>
+                <VoteDistributionGraphic votes={votesDataState.data} />
+              </div>
+            )}
+          </FetchDataContainer>
+        )}
+      </div>
+      {!isLastIndex && (
+        <ConnectBar
+          height={connectionLineValues.height}
+          top={connectionLineValues.top}
+          left={connectionLineValues.left}
+        />
+      )}
+    </div>
+  );
+};
+
+export { LegislativeHistoryNode };

--- a/src/components/Details/Legislation/ProgressBar.tsx
+++ b/src/components/Details/Legislation/ProgressBar.tsx
@@ -2,10 +2,9 @@ import React, { FC } from "react";
 import styled from "@emotion/styled";
 
 import { MATTER_STATUS_DECISION } from "../../../models/constants";
+import { Dot, DOT_SIZE, DOT_MARGIN } from "../../Shared/Dot";
 
 const PROGRESS_BAR_HEIGHT = 29;
-const DOT_SIZE = 20;
-const DOT_MARGIN = 6;
 const MID_POINT = `calc(50% + ${DOT_SIZE / 2}px + ${DOT_MARGIN + 2}px)`;
 
 const Progress = styled.div({
@@ -34,12 +33,6 @@ const Steps = styled.div<{ width: string; zIndex: number }>((props) => ({
     marginRight: DOT_MARGIN,
   },
 }));
-
-const Dot = styled.div({
-  width: DOT_SIZE,
-  height: DOT_SIZE,
-  borderRadius: "50%",
-});
 
 const Checkpoints = styled.div({
   display: "flex",

--- a/src/components/Details/Legislation/VoteBar.tsx
+++ b/src/components/Details/Legislation/VoteBar.tsx
@@ -37,6 +37,7 @@ const VoteBar: FC<VoteBarProps> = ({
   label,
 }: VoteBarProps) => {
   const [expanded, setExpanded] = useState(false);
+  const compactForm = useMediaQuery({ query: `(max-width: ${screenWidths.tablet})` });
 
   const votesLinks = votes.map((vote, i) => (
     <div key={`${i}_${vote.id}_vote`} style={{ marginTop: 4, display: "flex" }}>
@@ -44,10 +45,9 @@ const VoteBar: FC<VoteBarProps> = ({
         {vote.person?.name}
       </Link>
       <DecisionResult result={vote.decision} />
-      <Spacer style={{ flex: 4 }} />
+      {!compactForm && <Spacer style={{ flex: 4 }} />}
     </div>
   ));
-  const compactForm = useMediaQuery({ query: `(max-width: ${screenWidths.tablet})` });
   const directionality = compactForm ? "column" : "row";
   const barSize = compactForm ? "100%" : "80%";
   const textSize = compactForm ? "100%" : "20%";

--- a/src/components/Details/Legislation/VoteBar.tsx
+++ b/src/components/Details/Legislation/VoteBar.tsx
@@ -5,7 +5,9 @@ import { Link } from "react-router-dom";
 
 import { screenWidths } from "../../../styles/mediaBreakpoints";
 import Vote from "../../../models/Vote";
-import { strings } from "../../../assets/LocalizedStrings";
+import { DecisionResult } from "../../Shared";
+
+const Spacer = styled.div({ flex: 4 });
 
 const ColorBar = styled.div<{ width: string; zIndex: number; height: number }>((props) => ({
   position: "absolute",
@@ -37,22 +39,12 @@ const VoteBar: FC<VoteBarProps> = ({
   const [expanded, setExpanded] = useState(false);
 
   const votesLinks = votes.map((vote, i) => (
-    <div key={`${i}_${vote.id}_vote`} style={{ marginTop: 4 }}>
-      <Link to={`/people/${vote.id}`} style={{ marginLeft: 12 }}>
+    <div key={`${i}_${vote.id}_vote`} style={{ marginTop: 4, display: "flex" }}>
+      <Link to={`/people/${vote.id}`} style={{ marginLeft: 12, flex: 1 }}>
         {vote.person?.name}
       </Link>
-      <b style={{ marginLeft: 8 }}>
-        {
-          strings[
-            vote.decision
-              .toLowerCase()
-              .replace(" ", "_")
-              .replace("-", "_")
-              .replace("(", "")
-              .replace(")", "")
-          ]
-        }
-      </b>
+      <DecisionResult result={vote.decision} />
+      <Spacer style={{ flex: 4 }} />
     </div>
   ));
   const compactForm = useMediaQuery({ query: `(max-width: ${screenWidths.tablet})` });

--- a/src/components/Details/Legislation/VoteDistributionGraphic.tsx
+++ b/src/components/Details/Legislation/VoteDistributionGraphic.tsx
@@ -1,0 +1,58 @@
+import React, { FC, ReactNode } from "react";
+
+import Vote from "../../../models/Vote";
+import VoteBar from "./VoteBar";
+import { getVoteDistribution } from "../../Shared/util/voteDistribution";
+import { strings } from "../../../assets/LocalizedStrings";
+
+const VOTE_BAR_HEIGHT = 16;
+export interface VoteDistributionGraphicProps {
+  /** votes on the matter */
+  votes: Vote[];
+}
+
+const VoteDistributionGraphic: FC<VoteDistributionGraphicProps> = ({
+  votes,
+}: VoteDistributionGraphicProps) => {
+  const { inFavor, against, abstained } = getVoteDistribution(votes);
+  const votesForLabel: string = strings.number_approved.replace("{number}", `${inFavor.length}`);
+  const votesAgainstLabel: string = strings.number_rejected.replace(
+    "{number}",
+    `${against.length}`
+  );
+  const votesAbstainedLabel: string = strings.number_non_voting.replace(
+    "{number}",
+    `${abstained.length}`
+  );
+
+  const voteBars: ReactNode[] = [
+    <VoteBar
+      key={"inFavorVoteBar"}
+      statusColor={"cdp-bg-acceptance-green"}
+      votes={inFavor}
+      percentage={(inFavor.length / votes.length) * 100}
+      height={VOTE_BAR_HEIGHT}
+      label={votesForLabel}
+    />,
+    <VoteBar
+      key={"againstVoteBar"}
+      statusColor={"cdp-bg-rejected-red"}
+      votes={against}
+      percentage={(against.length / votes.length) * 100}
+      height={VOTE_BAR_HEIGHT}
+      label={votesAgainstLabel}
+    />,
+    <VoteBar
+      key={"abstainedVoteBar"}
+      statusColor={"cdp-bg-light-purple"}
+      votes={abstained}
+      percentage={(abstained.length / votes.length) * 100}
+      height={VOTE_BAR_HEIGHT}
+      label={votesAbstainedLabel}
+    />,
+  ];
+
+  return <div style={{ display: "flex", flexDirection: "column" }}>{voteBars}</div>;
+};
+
+export { VoteDistributionGraphic };

--- a/src/components/Shared/Dot.tsx
+++ b/src/components/Shared/Dot.tsx
@@ -1,0 +1,13 @@
+import styled from "@emotion/styled";
+
+const DOT_SIZE = 20;
+const DOT_MARGIN = 6;
+
+const Dot = styled.div({
+  width: DOT_SIZE,
+  height: DOT_SIZE,
+  borderRadius: "50%",
+  zIndex: 1,
+});
+
+export { Dot, DOT_MARGIN, DOT_SIZE };

--- a/src/containers/FetchDataContainer/LazyFetchDataContainer.tsx
+++ b/src/containers/FetchDataContainer/LazyFetchDataContainer.tsx
@@ -1,6 +1,7 @@
 import React, { FC, ReactNode } from "react";
 
 interface LazyFetchDataContainerProps {
+  /* the data prop is used to display message like Fetching <data>...No <data> found. */
   data: string;
   isLoading: boolean;
   error: Error | null;

--- a/src/networking/VoteService.ts
+++ b/src/networking/VoteService.ts
@@ -47,6 +47,25 @@ export default class VoteService extends ModelService {
     ) as Promise<Vote[]>;
   }
 
+  async getVotesByEventMinutesItemId(eventMinutesItemId: string): Promise<Vote[]> {
+    const networkQueryResponse = this.networkService.getDocuments(
+      COLLECTION_NAME.Vote,
+      [
+        where(
+          REF_PROPERTY_NAME.VoteEventMinutesItemRef,
+          WHERE_OPERATOR.eq,
+          doc(NetworkService.getDb(), COLLECTION_NAME.EventMinutesItem, eventMinutesItemId)
+        ),
+      ],
+      new PopulationOptions([new Populate(COLLECTION_NAME.Person, REF_PROPERTY_NAME.VotePersonRef)])
+    );
+    return this.createModels(
+      networkQueryResponse,
+      Vote,
+      `getVotesByEventMinutesItemId(${eventMinutesItemId})`
+    ) as Promise<Vote[]>;
+  }
+
   async getFullyPopulatedVotesByPersonId(
     personId: string,
     batchSize: number,

--- a/src/stories/model-mocks/eventMinutesItem.ts
+++ b/src/stories/model-mocks/eventMinutesItem.ts
@@ -1,18 +1,30 @@
 import EventMinutesItem from "../../models/EventMinutesItem";
 import { EVENT_MINUTES_ITEM_DECISION } from "../../models/constants";
+import { basicEvent } from "./event";
 
 const basicPassEventMinutesItem: EventMinutesItem = {
-  id: "passIdEventMinutesItem",
+  id: "f156c87a64f3",
   decision: EVENT_MINUTES_ITEM_DECISION.PASSED,
-  event_ref: "passeventref",
-  index: 10,
-  minutes_item_ref: "a5dae0358d16",
+  event_ref: "0b72b75170ec",
+  event: basicEvent,
+  index: 234,
+  minutes_item_ref: "e8a7fb715ea4",
 };
 const basicFailEventMinutesItem: EventMinutesItem = {
-  id: "failIdEventMinutesItem",
+  id: "93790abe707e",
   decision: EVENT_MINUTES_ITEM_DECISION.FAILED,
-  event_ref: "faileventref",
+  event_ref: "0b72b75170ec",
+  event: basicEvent,
   index: 11,
-  minutes_item_ref: "a5dae0358d16",
+  minutes_item_ref: "f5bf0a305",
 };
-export { basicPassEventMinutesItem, basicFailEventMinutesItem };
+
+const nonVotingEventMinutesItem: EventMinutesItem = {
+  id: "9b7fc6d73e64",
+  event_ref: "3c761f4cbd22",
+  event: basicEvent,
+  index: 7,
+  minutes_item_ref: "dc66d09feffb",
+};
+
+export { basicPassEventMinutesItem, basicFailEventMinutesItem, nonVotingEventMinutesItem };


### PR DESCRIPTION

### Link to Relevant Issue

This pull request resolves #175 

### Description of Changes

This completes one of the legislation tracking feature subcomponents: the legislation's history. 

This ended up being slightly different from the [proposed figma](https://www.figma.com/file/VPeHF2SVDn6FneLLl9bihB/Legislation-Tracking-(CDP)?node-id=137%3A350).  Instead of a plain unordered html list, I used colored Dots to indicate the decision reached (if any) at any particular EventMinutesItem in the timeline. This increased readability at a glance.

In addition, the vote details available in the expanded view leverage the already-created component VoteGraphicDistribution, meaning users can click into the votes for specific names of councilors. 

Legislative action is not currently available, which is unfortunate because that would have provided a neat title for each node on the timeline. The date of the associated Event is used instead, which at least provides some context. 

### Link to Forked Storybook Site

[storybook](https://brianl3.github.io/cdp-frontend/?path=/story/library-details-legislation-history--history)

