### PR TITLE
component/people-page

### DIFF
--- a/src/components/Cards/PersonCard/PersonCard.stories.tsx
+++ b/src/components/Cards/PersonCard/PersonCard.stories.tsx
@@ -2,6 +2,8 @@ import React from "react";
 import { Story, Meta } from "@storybook/react";
 
 import PersonCard, { PersonCardProps } from "./PersonCard";
+import { realPerson } from "../../../stories/model-mocks/person";
+import { realSeat, realSeatNoImage } from "../../../stories/model-mocks/seat";
 
 export default {
   component: PersonCard,
@@ -12,26 +14,12 @@ const Template: Story<PersonCardProps> = (args) => <PersonCard {...args} />;
 
 export const withSeatPicture = Template.bind({});
 withSeatPicture.args = {
-  personName: "Lisa Herbold",
-  personPictureSrc: "https://www.seattle.gov/images/Council/Members/Herbold/Herbold_225x225.jpg",
-  personIsActive: true,
-  seatName: "District 1",
-  seatElectoralArea: "West Seattle / South Park",
-  seatPictureSrc:
-    "https://uploads.visitseattle.org/2018/06/20095301/VSMap_Puget-Sound-e1529519202971-450x300.jpg",
-  chairedBodyNames: "Civil Rights, Utilities, Economic Development, and Arts Committee",
-  tenureStatus: "2nd term",
-  billsSponsored: 15,
+  person: realPerson,
+  seat: realSeat,
 };
 
 export const withoutSeatPicture = Template.bind({});
 withoutSeatPicture.args = {
-  personName: "Lisa Herbold",
-  personPictureSrc: "https://www.seattle.gov/images/Council/Members/Herbold/Herbold_225x225.jpg",
-  personIsActive: true,
-  seatName: "District 1",
-  seatElectoralArea: "West Seattle / South Park",
-  chairedBodyNames: "Civil Rights, Utilities, Economic Development, and Arts Committee",
-  tenureStatus: "2nd term",
-  billsSponsored: 15,
+  person: realPerson,
+  seat: realSeatNoImage,
 };

--- a/src/components/Cards/PersonCard/PersonCard.tsx
+++ b/src/components/Cards/PersonCard/PersonCard.tsx
@@ -1,4 +1,14 @@
-import React, { FC, ReactNode } from "react";
+import React, { FC, useCallback } from "react";
+import { useHistory } from "react-router-dom";
+import { useAppConfigContext } from "../../../app";
+
+import Person from "../../../models/Person";
+import Seat from "../../../models/Seat";
+import FileService from "../../../networking/FileService";
+
+import { FetchDataContainer } from "../../../containers/FetchDataContainer";
+import useFetchData from "../../../containers/FetchDataContainer/useFetchData";
+
 import styled from "@emotion/styled";
 import { strings } from "../../../assets/LocalizedStrings";
 
@@ -9,7 +19,6 @@ const PersonStatus = styled.div({
   borderRadius: "10%",
   padding: "0 4px",
 });
-
 interface ImgProps {
   left: string;
   width: string;
@@ -21,84 +30,92 @@ const Img = styled.img<ImgProps>((props) => ({
   width: `${props.width} !important`,
   height: "100%",
 }));
-
-const TenureP = styled.p({
-  // Decrease margin top to 12px from 24px for Tenure string
-  margin: `12px 0 0 !important`,
-});
-
 export interface PersonCardProps {
-  /** The person's name */
-  personName: string;
-  /** The person's picture */
-  personPictureSrc?: string;
-  /** Is the person a current councilmember? */
-  personIsActive: boolean;
-  /** The seat's name */
-  seatName: string;
-  /** The seat's electoral area */
-  seatElectoralArea: string;
-  /** The picture of the seat's electoral area */
-  seatPictureSrc?: string;
-  /** The bodies that the person chairs */
-  chairedBodyNames: ReactNode;
-  /** The person's tenure status */
-  tenureStatus: string;
-  /** The number of bills sponsored by the person */
-  billsSponsored: number;
+  /** the person represented */
+  person: Person;
+  /** the seat of the person represented */
+  seat: Seat;
 }
 
-const PersonCard: FC<PersonCardProps> = ({
-  personName,
-  personPictureSrc,
-  personIsActive,
-  seatName,
-  seatElectoralArea,
-  seatPictureSrc,
-  chairedBodyNames,
-  tenureStatus,
-  billsSponsored,
-}: PersonCardProps) => {
-  const seatHasPicture = seatPictureSrc !== undefined;
+interface PictureDataState {
+  personPictureSrc: string | undefined;
+  seatPictureSrc: string | undefined;
+}
+
+const PersonCard: FC<PersonCardProps> = ({ person, seat }: PersonCardProps) => {
+  const { firebaseConfig } = useAppConfigContext();
+  const history = useHistory();
+
+  /** Get the images for this card (at the same time so there isn't a double state update) */
+  const fetchPictures = useCallback(async () => {
+    const fileService = new FileService(firebaseConfig);
+    const { networkService } = fileService;
+    const pictures: PictureDataState = {
+      seatPictureSrc: undefined,
+      personPictureSrc: undefined,
+    };
+    if (seat.image_ref) {
+      const seatPicture = await fileService.getFileById(seat.image_ref);
+      pictures.seatPictureSrc = await networkService.getDownloadUrl(seatPicture.uri);
+    }
+    if (person.picture_ref) {
+      const personPicture = await fileService.getFileById(person.picture_ref);
+      pictures.personPictureSrc = await networkService.getDownloadUrl(personPicture.uri);
+    }
+
+    return Promise.resolve(pictures);
+  }, [person.picture_ref, seat.image_ref, firebaseConfig]);
+
+  //** initial state for fetching pictures */
+  const { state: pictureDataState } = useFetchData<PictureDataState>(
+    {
+      isLoading: false,
+      error: null,
+      hasFetchRequest: true,
+    },
+    fetchPictures
+  );
 
   return (
     <section className="mzp-c-card mzp-c-card-medium mzp-has-aspect-16-9">
-      <div className="mzp-c-card-block-link">
-        <div className="mzp-c-card-media-wrapper">
-          {personPictureSrc && (
-            <Img
-              className="mzp-c-card-image"
-              src={personPictureSrc}
-              width={seatHasPicture ? "40%" : "100%"}
-              left="0"
-              alt={personName}
-            />
-          )}
-          {seatHasPicture && (
-            <Img
-              className="mzp-c-card-image"
-              src={seatPictureSrc}
-              width="60%"
-              left="40%"
-              alt={`${seatName} - ${seatElectoralArea}`}
-            />
-          )}
-        </div>
-        <div className="mzp-c-card-content">
-          <h2 className="mzp-c-card-title">{personName}</h2>
-          <PersonStatus className={personIsActive ? "cdp-bg-neon-green" : "cdp-bg-dark-grey"}>
-            {personIsActive ? strings.active : strings.inactive}
-          </PersonStatus>
-          <p className="mzp-c-card-desc">
-            {seatName} &bull; {seatElectoralArea}
-          </p>
-          <p className="mzp-c-card-meta">{strings.chair}</p>
-          <p className="mzp-c-card-desc">{chairedBodyNames}</p>
-          <TenureP className="mzp-c-card-meta">{strings.tenure}</TenureP>
-          <p className="mzp-c-card-desc">
-            {tenureStatus} &bull; {billsSponsored} {strings.bills_sponsored}
-          </p>
-        </div>
+      <div
+        className="mzp-c-card-block-link"
+        onClick={() => {
+          history.push(`/people/${person.id}`);
+        }}
+      >
+        <FetchDataContainer isLoading={pictureDataState.isLoading} error={pictureDataState.error}>
+          <div className="mzp-c-card-media-wrapper">
+            {person.name}
+            {pictureDataState.data && (
+              <Img
+                className="mzp-c-card-image"
+                src={pictureDataState.data.personPictureSrc}
+                width={pictureDataState.data.seatPictureSrc ? "40%" : "100%"}
+                left="0"
+                alt={person.name}
+              />
+            )}
+            {pictureDataState.data?.seatPictureSrc && (
+              <Img
+                className="mzp-c-card-image"
+                src={pictureDataState.data.seatPictureSrc}
+                width="60%"
+                left="40%"
+                alt={`${seat.name} - ${seat.electoral_area}`}
+              />
+            )}
+          </div>
+          <div className="mzp-c-card-content">
+            <h2 className="mzp-c-card-title">{person.name}</h2>
+            <PersonStatus className={person.is_active ? "cdp-bg-neon-green" : "cdp-bg-dark-grey"}>
+              {person.is_active ? strings.active : strings.inactive}
+            </PersonStatus>
+            <p className="mzp-c-card-desc">
+              {seat.name} &bull; {seat.electoral_area}
+            </p>
+          </div>
+        </FetchDataContainer>
       </div>
     </section>
   );

--- a/src/containers/PeopleContainer/PeopleContainer.tsx
+++ b/src/containers/PeopleContainer/PeopleContainer.tsx
@@ -1,35 +1,69 @@
 import React from "react";
-import { PeoplePageData } from "./types";
-import Person from "../../models/Person";
-import { Link } from "react-router-dom";
-export interface PeopleContainerProps extends PeoplePageData {
+
+import Seat from "../../models/Seat";
+import Role from "../../models/Role";
+
+import H2 from "../../components/Shared/H2";
+import { PersonCard } from "../../components/Cards/PersonCard";
+
+import styled from "@emotion/styled";
+import { useMediaQuery } from "react-responsive";
+import { screenWidths } from "../../styles/mediaBreakpoints";
+
+export interface PeopleContainerProps {
   /** Any extra info */
   searchQuery?: string;
+  /** all current councilor roles (with Person populated) */
+  roles: Role[];
+  /** the seats associated with the above councilmembers (ordered) */
+  seats: Seat[];
 }
 
-function renderLinkCard(person: Person) {
-  return (
-    <div>
-      <Link to={`/people/${person.id}`}>{person.name}</Link>
-    </div>
-  );
-}
+const PersonContainer = ({ roles, seats }: PeopleContainerProps) => {
+  const isMobile = useMediaQuery({ query: `(max-width: ${screenWidths.tablet})` });
 
-const PersonContainer = ({ currentPeople, allPeople }: PeopleContainerProps) => {
+  const CardRow = styled.div({
+    display: "flex",
+    flexDirection: isMobile ? "column" : "row",
+    gap: 8,
+    flex: 1,
+  });
+
+  const CardCell = styled.div({
+    flex: 1,
+    maxWidth: "50%",
+  });
+
   return (
     <div>
-      <h3>Currently Elected</h3>
-      {currentPeople &&
-        currentPeople.map((role) => {
+      <H2>Current Councilmembers</H2>
+      {roles.map((role, index) => {
+        if (index % 2 === 0) {
+          const role2 = roles[index + 1];
           if (role.person) {
-            return renderLinkCard(role.person);
+            return (
+              <CardRow>
+                <CardCell>
+                  <PersonCard
+                    key={`person-card-${role.person?.name}`}
+                    person={role.person}
+                    seat={seats[index]}
+                  />
+                </CardCell>
+                {role2 && role2.person && (
+                  <CardCell>
+                    <PersonCard
+                      key={`person-card-${role2.person.name}`}
+                      person={role2.person}
+                      seat={seats[index + 1]}
+                    />
+                  </CardCell>
+                )}
+              </CardRow>
+            );
           }
-        })}
-      <h3>All</h3>
-      {allPeople &&
-        allPeople.map((person) => {
-          return renderLinkCard(person);
-        })}
+        }
+      })}
     </div>
   );
 };

--- a/src/containers/PeopleContainer/types.ts
+++ b/src/containers/PeopleContainer/types.ts
@@ -1,9 +1,0 @@
-import Person from "../../models/Person";
-import Role from "../../models/Role";
-
-export interface PeoplePageData {
-  /**The currently-elected people */
-  currentPeople: Role[];
-  /** all people */
-  allPeople: Person[];
-}

--- a/src/networking/PersonService.ts
+++ b/src/networking/PersonService.ts
@@ -29,10 +29,4 @@ export default class PersonService extends ModelService {
       `getPersonById(${personId})`
     ) as Promise<Person>;
   }
-
-  async getAllPeople(): Promise<Person[]> {
-    const networkResponse = this.networkService.getDocuments(COLLECTION_NAME.Person, []);
-
-    return this.createModels(networkResponse, Person, `getAllPeople`) as Promise<Person[]>;
-  }
 }

--- a/src/networking/SeatService.ts
+++ b/src/networking/SeatService.ts
@@ -1,0 +1,16 @@
+import ModelService from "./ModelService";
+import Seat from "../models/Seat";
+import { COLLECTION_NAME } from "./PopulationOptions";
+import { FirebaseConfig } from "../app/AppConfigContext";
+
+export default class SeatService extends ModelService {
+  constructor(firebaseConfig: FirebaseConfig) {
+    super(COLLECTION_NAME.Seat, firebaseConfig);
+  }
+
+  async getAllSeats(): Promise<Seat[]> {
+    const networkResponse = this.networkService.getDocuments(COLLECTION_NAME.Seat, []);
+
+    return this.createModels(networkResponse, Seat, `getAllSeats`) as Promise<Seat[]>;
+  }
+}

--- a/src/stories/model-mocks/person.ts
+++ b/src/stories/model-mocks/person.ts
@@ -12,4 +12,16 @@ const basicPerson: Person = {
   is_active: true,
 };
 
-export { basicPerson };
+const realPerson: Person = {
+  id: "975edb7a71f6",
+  name: "Teresa Mosqueda",
+  email: "Teresa.Mosqueda@seattle.gov",
+  phone: "206-867-5309",
+  website: "http://www.seattle.gov/council/mosqueda",
+  picture: undefined,
+  picture_ref: "e2ac924a1884",
+  router_string: "teresa-mosqueda",
+  is_active: true,
+};
+
+export { basicPerson, realPerson };

--- a/src/stories/model-mocks/seat.ts
+++ b/src/stories/model-mocks/seat.ts
@@ -10,4 +10,22 @@ const basicSeat: Seat = {
   external_source_id: "test-external-source-id",
 };
 
-export { basicSeat };
+const realSeat: Seat = {
+  id: "a3c0719eef4a",
+  electoral_area: "West Seattle",
+  electoral_type: undefined,
+  external_source_id: undefined,
+  image_ref: "1607b20993bf",
+  name: "Position 1",
+};
+
+const realSeatNoImage: Seat = {
+  id: "a3c0719eef4a",
+  electoral_area: "West Seattle",
+  electoral_type: undefined,
+  external_source_id: undefined,
+  image_ref: undefined,
+  name: "Position 1",
+};
+
+export { basicSeat, realSeat, realSeatNoImage };


### PR DESCRIPTION
### Link to Relevant Issue

As prep for completion of #164 I added PersonCards to the PeoplePage.

### Description of Changes

I also changed the way we query for the current council (those displayed on the People page). This seems to be more accurate and lists the current council without listing any weird entities like "No Sponsor".

PersonCard was refactored as well. Each Card now receives a role(and person) and seat as props, and then fetches its own images. 

### Link to Deployed Staged Environment
See [here](https://brianl3.github.io/cdp-frontend/#/people)  to see the new PeoplePage.

_Please see `CONTRIBUTING.md` for directions on how this can be done._
