### PR TITLE
fix/use-placeholderwrapper-in-person-card

### DIFF
--- a/src/constants/ProjectConstants.ts
+++ b/src/constants/ProjectConstants.ts
@@ -1,3 +1,17 @@
+import exampleCover1 from "../assets/images/dave-hoefler-reduced-1.jpg";
+import exampleCover2 from "../assets/images/dave-hoefler-reduced-2.jpg";
+import exampleCover3 from "../assets/images/dave-hoefler-reduced-3.jpg";
+import exampleCover4 from "../assets/images/dave-hoefler-reduced-4.jpg";
+import exampleCover5 from "../assets/images/dave-hoefler-reduced-5.jpg";
+
 export const SUPPORTED_LANGUAGES = ["en", "de", "es"];
 
 export const FETCH_CARDS_BATCH_SIZE = 10;
+
+export const EXAMPLE_COVER_VIEWS = [
+  exampleCover1,
+  exampleCover2,
+  exampleCover3,
+  exampleCover4,
+  exampleCover5,
+];

--- a/src/containers/PersonContainer/CoverImage.tsx
+++ b/src/containers/PersonContainer/CoverImage.tsx
@@ -5,21 +5,9 @@ import { FetchDataState } from "../FetchDataContainer/useFetchData";
 
 import PlaceholderWrapper from "../../components/Shared/PlaceHolder";
 
+import { EXAMPLE_COVER_VIEWS } from "../../constants/ProjectConstants";
+
 import { screenWidths } from "../../styles/mediaBreakpoints";
-
-import exampleCover1 from "../../assets/images/dave-hoefler-reduced-1.jpg";
-import exampleCover2 from "../../assets/images/dave-hoefler-reduced-2.jpg";
-import exampleCover3 from "../../assets/images/dave-hoefler-reduced-3.jpg";
-import exampleCover4 from "../../assets/images/dave-hoefler-reduced-4.jpg";
-import exampleCover5 from "../../assets/images/dave-hoefler-reduced-5.jpg";
-
-const EXAMPLE_COVER_VIEWS = [
-  exampleCover1,
-  exampleCover2,
-  exampleCover3,
-  exampleCover4,
-  exampleCover5,
-];
 
 const EXAMPLE_COVER_VIEW =
   EXAMPLE_COVER_VIEWS[Math.floor(Math.random() * EXAMPLE_COVER_VIEWS.length)];


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  ⚠️⚠️ Please do the following before submitting: ⚠️⚠️

  - Read the CONTRIBUTING.md guide and make sure you've followed all the steps given.
  - Ensure that the code is up-to-date with the `main` branch.
  - Provide or update documentation for any feature added by your pull request.
  - Provide relevant tests for your feature or bug fix.

  ❗️ Also: ❗️

  Please name your pull request {development-type}/{short-description}.
  For example: feature/read-tiff-files
-->

### Link to Relevant Issue

This pull request resolves #

### Description of Changes

_Include a description of the proposed changes._
Building on top of the [people page pr](https://github.com/CouncilDataProject/cdp-frontend/pull/209#issuecomment-1072903747) -- fixing a leftover issue. 
> I like delegating fetching the pictures to PersonCard. But FetchDataContainer is not appropriate for this component. When the images are loading, there is a bunch of loading spinners all in the same spot and as a result, it doesn't look like a spinner anymore. The better alternative is to use PlaceholderWrapper (similar to the cover image in the person page). It's a little complicated to implement and I can make a PR for it.

In the person card, use PlaceholderWrapper instead of FetchDataContainer to show the pictures are loading.

### Link to Forked Storybook Site

_If component changes (especially visual changes) are contained in this PR, we ask that you provide a link to a publicly viewable version of the Storybook docs site, so PR reviewers can see your changes without having to install and view your code locally._

_Please see `CONTRIBUTING.md` for directions on how this can be done._
https://tohuynh.github.io/cdp-frontend/#/people
