### PR TITLE
feature/matter-page

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -102,7 +102,7 @@ function App() {
                 <Route exact path="/people/:id">
                   <PersonPage />
                 </Route>
-                <Route exact path="/matter/:id">
+                <Route exact path="/matters/:id">
                   <MatterPage />
                 </Route>
               </Switch>

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -16,6 +16,7 @@ import { EventPage } from "../pages/EventPage";
 import { EventsPage } from "../pages/EventsPage";
 import { PersonPage } from "../pages/PersonPage";
 import { PeoplePage } from "../pages/PeoplePage";
+import { MatterPage } from "../pages/MatterPage";
 
 import { SEARCH_TYPE } from "../pages/SearchPage/types";
 
@@ -100,6 +101,9 @@ function App() {
                 </Route>
                 <Route exact path="/people/:id">
                   <PersonPage />
+                </Route>
+                <Route exact path="/matter/:id">
+                  <MatterPage />
                 </Route>
               </Switch>
             </Main>

--- a/src/assets/LocalizedStrings.tsx
+++ b/src/assets/LocalizedStrings.tsx
@@ -100,6 +100,7 @@ export interface MasterStringsList extends LocalizedStringsMethods {
   latest_vote: string;
   history: string;
   minutes: string;
+  go_to_matter_details: string;
 }
 
 // Note: Add languages to video.js in /src/pages/EventPage/utils when adding new languages

--- a/src/assets/strings/de.ts
+++ b/src/assets/strings/de.ts
@@ -89,6 +89,7 @@ const de = {
   latest_vote: "Letzte Abstimmung",
   history: "Geschichte",
   minutes: "Protokoll",
+  go_to_matter_details: "Gehen Sie zu den vollständigen Rechtsvorschriften",
 };
 
 export default de;

--- a/src/assets/strings/en.ts
+++ b/src/assets/strings/en.ts
@@ -88,6 +88,7 @@ const en = {
   latest_vote: "Latest Vote",
   history: "History",
   minutes: "Minutes",
+  go_to_matter_details: "Go to Full Legislation Details",
 };
 
 export default en;

--- a/src/assets/strings/es.ts
+++ b/src/assets/strings/es.ts
@@ -88,6 +88,7 @@ const es = {
   latest_vote: "Último Voto",
   history: "Historia",
   minutes: "Protocolo",
+  go_to_matter_details: "Ir a los detalles completos de la legislación",
 };
 
 export default es;

--- a/src/components/Details/Legislation/LegislationIntroduction.tsx
+++ b/src/components/Details/Legislation/LegislationIntroduction.tsx
@@ -38,12 +38,13 @@ const LegislationIntroduction: FC<LegislationIntroductionProps> = ({
             flex: 1,
           }}
         >
-          {indexedMatterGrams.map((indexedMatterGram) => (
-            <div key={indexedMatterGram.id}>
-              <p style={{ display: "inline", paddingLeft: 11, paddingRight: 11 }}>•</p>
-              <p style={{ display: "inline" }}>{indexedMatterGram.unstemmed_gram}</p>
-            </div>
-          ))}
+          {indexedMatterGrams &&
+            indexedMatterGrams.map((indexedMatterGram) => (
+              <div key={indexedMatterGram.id}>
+                <p style={{ display: "inline", paddingLeft: 11, paddingRight: 11 }}>•</p>
+                <p style={{ display: "inline" }}>{indexedMatterGram.unstemmed_gram}</p>
+              </div>
+            ))}
         </div>
       </div>
     </div>

--- a/src/components/Details/Legislation/LegislationOverview.tsx
+++ b/src/components/Details/Legislation/LegislationOverview.tsx
@@ -101,10 +101,10 @@ const LegislationOverview: FC<LegislationOverviewProps> = ({
             <ProgressBar status={matterStatus.status} />
           </dd>
         </div>
-        <div>
-          <dt>Latest Meeting:</dt>
-          <dd>
-            {event && (
+        {event && (
+          <div>
+            <dt>Latest Meeting:</dt>
+            <dd>
               <Link to={`/events/${event.id}`}>
                 {event.event_datetime.toLocaleDateString("en-US", {
                   month: "short",
@@ -112,9 +112,9 @@ const LegislationOverview: FC<LegislationOverviewProps> = ({
                   year: "numeric",
                 })}
               </Link>
-            )}
-          </dd>
-        </div>
+            </dd>
+          </div>
+        )}
         {document && (
           <div>
             <dt>Latest Document:</dt>

--- a/src/components/Details/Legislation/LegislationOverview.tsx
+++ b/src/components/Details/Legislation/LegislationOverview.tsx
@@ -63,11 +63,11 @@ export interface LegislationOverviewProps {
   /** The latest matter status of the matter */
   matterStatus: MatterStatus;
   /** The latest event where the matter was a minutes item */
-  event: Event;
+  event?: Event;
   /** The persons who sponsored the matter */
   sponsors: Person[];
   /** The latest document of  the matter */
-  document: { name: string; url: string };
+  document?: { name: string; url: string };
 }
 
 const LegislationOverview: FC<LegislationOverviewProps> = ({
@@ -104,23 +104,27 @@ const LegislationOverview: FC<LegislationOverviewProps> = ({
         <div>
           <dt>Latest Meeting:</dt>
           <dd>
-            <Link to={`/events/${event.id}`}>
-              {event.event_datetime.toLocaleDateString("en-US", {
-                month: "short",
-                day: "numeric",
-                year: "numeric",
-              })}
-            </Link>
+            {event && (
+              <Link to={`/events/${event.id}`}>
+                {event.event_datetime.toLocaleDateString("en-US", {
+                  month: "short",
+                  day: "numeric",
+                  year: "numeric",
+                })}
+              </Link>
+            )}
           </dd>
         </div>
-        <div>
-          <dt>Latest Document:</dt>
-          <dd>
-            <a target="_blank" rel="noopener noreferrer" href={document.url}>
-              {document.name}
-            </a>
-          </dd>
-        </div>
+        {document && (
+          <div>
+            <dt>Latest Document:</dt>
+            <dd>
+              <a target="_blank" rel="noopener noreferrer" href={document.url}>
+                {document.name}
+              </a>
+            </dd>
+          </div>
+        )}
         <div>
           <dt>Sponsored by:</dt>
           <dd>

--- a/src/components/Details/MinutesItemsList/MinutesItemsList.tsx
+++ b/src/components/Details/MinutesItemsList/MinutesItemsList.tsx
@@ -1,11 +1,12 @@
 import React, { FC } from "react";
 import styled from "@emotion/styled";
-/* import { Link } from "react-router-dom"; */
+import { Link } from "react-router-dom";
 
 import DocumentsList from "./DocumentsList";
-/* import ChevronDownIcon from "../../Shared/ChevronDownIcon"; */
+import ChevronDownIcon from "../../Shared/ChevronDownIcon";
 
 import { Item } from "./types";
+import { strings } from "../../../assets/LocalizedStrings";
 
 const ListItem = styled.li({
   "& > div:first-of-type": {
@@ -37,11 +38,11 @@ const MinutesItemsList: FC<MinutesItemsListProps> = ({ minutesItems }: MinutesIt
         return (
           <ListItem key={elem.name}>
             <div>{elem.name}</div>
-            {/* {elem.matter_ref && (
+            {elem.matter_ref && (
               <Link to={`/matters/${elem.matter_ref}`}>
-                {"Go to Full Legislation Details"} <ChevronDownIcon />
+                {strings.go_to_matter_details} <ChevronDownIcon />
               </Link>
-            )} */}
+            )}
             {elem.description && <div>{elem.description}</div>}
             <DocumentsList documents={elem.documents} />
           </ListItem>

--- a/src/components/Tables/MeetingVotesTableRow/MeetingVotesTableRow.tsx
+++ b/src/components/Tables/MeetingVotesTableRow/MeetingVotesTableRow.tsx
@@ -98,7 +98,7 @@ function VoteCell(isExpanded: boolean, votes: IndividualMeetingVote[], isMobile:
 
 const MeetingVotesTableRow = ({
   index,
-  /* legislationLink, */
+  legislationLink,
   legislationName,
   legislationDescription,
   councilDecision,
@@ -120,10 +120,11 @@ const MeetingVotesTableRow = ({
       }}
     >
       <div>
-        {/* <Link to={legislationLink}>{legislationName}</Link> */}
-        <p className="mzp-c-card-desc" style={{ fontWeight: 600, marginBottom: 0 }}>
-          {legislationName}
-        </p>
+        <Link to={legislationLink}>
+          <p className="mzp-c-card-desc" style={{ fontWeight: 600, marginBottom: 0 }}>
+            {legislationName}
+          </p>
+        </Link>
         {!isMobile && <p>{legislationDescription}</p>}
       </div>
       <DecisionResult result={councilDecision} />

--- a/src/components/Tables/VotingTableRow/VotingTableRow.tsx
+++ b/src/components/Tables/VotingTableRow/VotingTableRow.tsx
@@ -35,7 +35,7 @@ export type VotingTableRowProps = {
 
 const VotingTableRow = ({
   index,
-  /* legislationLink, */
+  legislationLink,
   legislationName,
   legislationTags,
   voteDecision,
@@ -65,10 +65,11 @@ const VotingTableRow = ({
       columnDistribution={columnDistribution}
     >
       <React.Fragment>
-        {/* <Link to={legislationLink}>{legislationName}</Link> */}
-        <p className="mzp-c-card-desc" style={{ fontWeight: 600, marginBottom: 0 }}>
-          {legislationName}
-        </p>
+        <Link to={legislationLink}>
+          <p className="mzp-c-card-desc" style={{ fontWeight: 600, marginBottom: 0 }}>
+            {legislationName}
+          </p>
+        </Link>
         {!isMobile && <p className="mzp-c-card-desc">{legislationTagsString}</p>}
       </React.Fragment>
       <DecisionResult result={voteDecision} />

--- a/src/containers/MatterContainer/MatterContainer.tsx
+++ b/src/containers/MatterContainer/MatterContainer.tsx
@@ -1,0 +1,45 @@
+import React from "react";
+
+import MatterStatus from "../../models/MatterStatus";
+import Event from "../../models/Event";
+import Person from "../../models/Person";
+import Vote from "../../models/Vote";
+import IndexedMatterGram from "../../models/IndexedMatterGram";
+import EventMinutesItem from "../../models/EventMinutesItem";
+
+import LegislationIntroduction from "../../components/Details/Legislation/LegislationIntroduction";
+import LegislationOverview from "../../components/Details/Legislation/LegislationOverview";
+import { LegislationLatestVote } from "../../components/Details/Legislation/LegislationLatestVote";
+import { LegislationHistory } from "../../components/Details/Legislation/LegislationHistory";
+
+interface MatterContainerProps {
+  matterStatus: MatterStatus;
+  indexedMatterGrams: IndexedMatterGram[];
+  event?: Event;
+  sponsors: Person[];
+  votes?: Vote[];
+  legislationHistory?: EventMinutesItem[];
+}
+
+const MatterContainer = ({
+  matterStatus,
+  indexedMatterGrams,
+  event,
+  sponsors,
+  votes,
+  legislationHistory,
+}: MatterContainerProps) => {
+  return (
+    <div>
+      <LegislationIntroduction
+        matterStatus={matterStatus}
+        indexedMatterGrams={indexedMatterGrams}
+      />
+      <LegislationOverview matterStatus={matterStatus} event={event} sponsors={sponsors} />
+      {votes && <LegislationLatestVote votes={votes} />}
+      {legislationHistory && <LegislationHistory eventMinutesItems={legislationHistory} />}
+    </div>
+  );
+};
+
+export default MatterContainer;

--- a/src/containers/MatterContainer/MatterContainer.tsx
+++ b/src/containers/MatterContainer/MatterContainer.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import styled from "@emotion/styled";
 
 import MatterStatus from "../../models/MatterStatus";
 import Event from "../../models/Event";
@@ -12,6 +13,11 @@ import LegislationOverview from "../../components/Details/Legislation/Legislatio
 import { LegislationLatestVote } from "../../components/Details/Legislation/LegislationLatestVote";
 import { LegislationHistory } from "../../components/Details/Legislation/LegislationHistory";
 
+const Matter = styled.div({
+  display: "grid",
+  gridTemplateColumns: "1fr",
+  rowGap: 64,
+});
 interface MatterContainerProps {
   matterStatus: MatterStatus;
   indexedMatterGrams: IndexedMatterGram[];
@@ -30,7 +36,7 @@ const MatterContainer = ({
   legislationHistory,
 }: MatterContainerProps) => {
   return (
-    <div>
+    <Matter>
       <LegislationIntroduction
         matterStatus={matterStatus}
         indexedMatterGrams={indexedMatterGrams}
@@ -38,7 +44,7 @@ const MatterContainer = ({
       <LegislationOverview matterStatus={matterStatus} event={event} sponsors={sponsors} />
       {votes && <LegislationLatestVote votes={votes} />}
       {legislationHistory && <LegislationHistory eventMinutesItems={legislationHistory} />}
-    </div>
+    </Matter>
   );
 };
 

--- a/src/containers/MatterContainer/index.ts
+++ b/src/containers/MatterContainer/index.ts
@@ -1,0 +1,1 @@
+export { default as MatterContainer } from "./MatterContainer";

--- a/src/containers/PersonContainer/MattersSponsored.tsx
+++ b/src/containers/PersonContainer/MattersSponsored.tsx
@@ -74,14 +74,14 @@ const MattersSponsored: FC<MattersSponsoredProps> = ({ personId }: MattersSponso
           {state.models.map((matterSponsored) => (
             <li key={matterSponsored.id}>
               <dl>
-                <Link
-                  key={matterSponsored.matter?.id}
-                  to={`/matters/${matterSponsored.matter?.id}`}
-                >
-                  <dt>
+                <dt>
+                  <Link
+                    key={matterSponsored.matter?.id}
+                    to={`/matters/${matterSponsored.matter?.id}`}
+                  >
                     <strong>{matterSponsored.matter?.name}</strong>
-                  </dt>
-                </Link>
+                  </Link>
+                </dt>
                 <dd>{matterSponsored.matter?.title}</dd>
               </dl>
             </li>

--- a/src/containers/PersonContainer/MattersSponsored.tsx
+++ b/src/containers/PersonContainer/MattersSponsored.tsx
@@ -1,5 +1,6 @@
 import React, { FC, useMemo, useCallback } from "react";
 import { Loader } from "semantic-ui-react";
+import { Link } from "react-router-dom";
 
 import { useAppConfigContext } from "../../app";
 import useFetchModels, {
@@ -73,9 +74,14 @@ const MattersSponsored: FC<MattersSponsoredProps> = ({ personId }: MattersSponso
           {state.models.map((matterSponsored) => (
             <li key={matterSponsored.id}>
               <dl>
-                <dt>
-                  <strong>{matterSponsored.matter?.name}</strong>
-                </dt>
+                <Link
+                  key={matterSponsored.matter?.id}
+                  to={`/matters/${matterSponsored.matter?.id}`}
+                >
+                  <dt>
+                    <strong>{matterSponsored.matter?.name}</strong>
+                  </dt>
+                </Link>
                 <dd>{matterSponsored.matter?.title}</dd>
               </dl>
             </li>

--- a/src/networking/MatterSponsorService.ts
+++ b/src/networking/MatterSponsorService.ts
@@ -27,6 +27,29 @@ export default class MatterSponsorService extends ModelService {
     super(COLLECTION_NAME.MatterSponsor, firebaseConfig);
   }
 
+  async getMatterSponsorByMatterId(matterId: string): Promise<MatterSponsor[]> {
+    const populatePerson = new Populate(
+      COLLECTION_NAME.MatterSponsor,
+      REF_PROPERTY_NAME.MatterSponsorPersonRef
+    );
+    const networkQueryResponse = this.networkService.getDocuments(
+      COLLECTION_NAME.MatterSponsor,
+      [
+        where(
+          REF_PROPERTY_NAME.MatterSponsorMatterRef,
+          WHERE_OPERATOR.eq,
+          doc(NetworkService.getDb(), COLLECTION_NAME.Matter, matterId)
+        ),
+      ],
+      new PopulationOptions([populatePerson])
+    );
+    return this.createModels(
+      networkQueryResponse,
+      MatterSponsor,
+      `getMatterSponsorByMatterId(${matterId})`
+    ) as Promise<MatterSponsor[]>;
+  }
+
   /**
    *
    * @param personId The person's id

--- a/src/networking/MatterStatusService.ts
+++ b/src/networking/MatterStatusService.ts
@@ -1,0 +1,48 @@
+import ModelService from "./ModelService";
+import { where, orderBy, doc } from "@firebase/firestore";
+import {
+  COLLECTION_NAME,
+  Populate,
+  PopulationOptions,
+  REF_PROPERTY_NAME,
+} from "./PopulationOptions";
+import { ORDER_DIRECTION, WHERE_OPERATOR } from "./constants";
+import { NetworkService } from "./NetworkService";
+
+import MatterStatus from "../models/MatterStatus";
+import { FirebaseConfig } from "../app/AppConfigContext";
+
+export default class MatterStatusService extends ModelService {
+  constructor(firebaseConfig: FirebaseConfig) {
+    super(COLLECTION_NAME.MatterStatus, firebaseConfig);
+  }
+
+  async getMatterStatusesByMatterId(matterId: string): Promise<MatterStatus[]> {
+    const populateMatter = new Populate(
+      COLLECTION_NAME.MatterStatus,
+      REF_PROPERTY_NAME.MatterStatusMatterRef
+    );
+    const populateEventMinutesItems = new Populate(
+      COLLECTION_NAME.MatterStatus,
+      REF_PROPERTY_NAME.MatterStatusEventMinutesItemRef
+    );
+
+    const networkQueryResponse = this.networkService.getDocuments(
+      COLLECTION_NAME.MatterStatus,
+      [
+        where(
+          REF_PROPERTY_NAME.MatterStatusMatterRef,
+          WHERE_OPERATOR.eq,
+          doc(NetworkService.getDb(), COLLECTION_NAME.Matter, matterId)
+        ),
+        orderBy("update_datetime", ORDER_DIRECTION.desc),
+      ],
+      new PopulationOptions([populateMatter, populateEventMinutesItems])
+    );
+    return this.createModels(
+      networkQueryResponse,
+      MatterStatus,
+      `getMatterStatusByMatterId(${matterId})`
+    ) as Promise<MatterStatus[]>;
+  }
+}

--- a/src/networking/MatterStatusService.ts
+++ b/src/networking/MatterStatusService.ts
@@ -18,10 +18,6 @@ export default class MatterStatusService extends ModelService {
   }
 
   async getMatterStatusesByMatterId(matterId: string): Promise<MatterStatus[]> {
-    const populateMatter = new Populate(
-      COLLECTION_NAME.MatterStatus,
-      REF_PROPERTY_NAME.MatterStatusMatterRef
-    );
     const populateEventMinutesItems = new Populate(
       COLLECTION_NAME.MatterStatus,
       REF_PROPERTY_NAME.MatterStatusEventMinutesItemRef
@@ -37,7 +33,7 @@ export default class MatterStatusService extends ModelService {
         ),
         orderBy("update_datetime", ORDER_DIRECTION.desc),
       ],
-      new PopulationOptions([populateMatter, populateEventMinutesItems])
+      new PopulationOptions([populateEventMinutesItems])
     );
     return this.createModels(
       networkQueryResponse,

--- a/src/pages/MatterPage/MatterPage.tsx
+++ b/src/pages/MatterPage/MatterPage.tsx
@@ -1,0 +1,110 @@
+import React, { FC, useCallback } from "react";
+import { useParams } from "react-router-dom";
+import { useAppConfigContext } from "../../app";
+import useFetchData from "../../containers/FetchDataContainer/useFetchData";
+import FetchDataContainer from "../../containers/FetchDataContainer/FetchDataContainer";
+import { MatterContainer } from "../../containers/MatterContainer";
+
+import MatterStatus from "../../models/MatterStatus";
+import IndexedMatterGram from "../../models/IndexedMatterGram";
+import EventMinutesItem from "../../models/EventMinutesItem";
+import Event from "../../models/Event";
+import Person from "../../models/Person";
+import Vote from "../../models/Vote";
+
+import MatterStatusService from "../../networking/MatterStatusService";
+import EventService from "../../networking/EventService";
+import MatterSponsorService from "../../networking/MatterSponsorService";
+import VoteService from "../../networking/VoteService";
+
+interface MatterContainerType {
+  matterStatus: MatterStatus;
+  indexedMatterGrams: IndexedMatterGram[];
+  event?: Event;
+  sponsors: Person[];
+  votes?: Vote[];
+  legislationHistory: EventMinutesItem[];
+}
+
+const MatterPage: FC = () => {
+  // Get the app config context
+  const { firebaseConfig } = useAppConfigContext();
+  // Get the id the matter, provided the route is `matter/:id`
+  const { id } = useParams<{ id: string }>();
+  //TODO: change these to Promise.all
+
+  const fetchMatterStatus = useCallback(async () => {
+    const matterStatusService = new MatterStatusService(firebaseConfig);
+    const matterSponsorService = new MatterSponsorService(firebaseConfig);
+    const eventService = new EventService(firebaseConfig);
+
+    const matterSponsors = await matterSponsorService.getMatterSponsorByMatterId(id);
+    const sponsors = matterSponsors
+      .filter((matterSponsor) => {
+        return matterSponsor.person;
+      })
+      .map((matterSponsor) => {
+        return matterSponsor.person as Person;
+      });
+
+    const matterStatuses = await matterStatusService.getMatterStatusesByMatterId(id);
+    const legislationHistory = matterStatuses.reduce((filtered, optional) => {
+      if (optional.event_minutes_item) {
+        filtered.push(optional.event_minutes_item);
+      }
+      return filtered;
+    }, [] as EventMinutesItem[]);
+
+    const latestStatus = matterStatuses[0];
+    const matterContainerData: MatterContainerType = {
+      matterStatus: latestStatus,
+      indexedMatterGrams: [],
+      sponsors,
+      legislationHistory,
+    };
+
+    // loop through matterStatuses until we find one where the
+    // event_minutes_item is not null
+    let latestEventMinutesItem: EventMinutesItem | undefined;
+    for (const matterStatus of matterStatuses) {
+      if (matterStatus.event_minutes_item) {
+        latestEventMinutesItem = matterStatus.event_minutes_item;
+        break;
+      }
+    }
+    if (latestEventMinutesItem) {
+      const votesService = new VoteService(firebaseConfig);
+      matterContainerData.votes = await votesService.getVotesByEventMinutesItemId(
+        latestEventMinutesItem.id
+      );
+      matterContainerData.event = await eventService.getEventById(latestEventMinutesItem.event_ref);
+    }
+    return matterContainerData;
+  }, [firebaseConfig, id]);
+
+  const { state: matterStatusState } = useFetchData<MatterContainerType>(
+    {
+      isLoading: false,
+      error: null,
+      hasFetchRequest: true,
+    },
+    fetchMatterStatus
+  );
+
+  return (
+    <FetchDataContainer isLoading={matterStatusState.isLoading} error={matterStatusState.error}>
+      {matterStatusState.data && (
+        <MatterContainer
+          indexedMatterGrams={matterStatusState.data.indexedMatterGrams}
+          matterStatus={matterStatusState.data.matterStatus}
+          sponsors={matterStatusState.data.sponsors}
+          event={matterStatusState.data.event}
+          votes={matterStatusState.data.votes}
+          legislationHistory={matterStatusState.data.legislationHistory}
+        />
+      )}
+    </FetchDataContainer>
+  );
+};
+
+export default MatterPage;

--- a/src/pages/MatterPage/index.ts
+++ b/src/pages/MatterPage/index.ts
@@ -1,0 +1,1 @@
+export { default as MatterPage } from "./MatterPage";


### PR DESCRIPTION
### Link to Relevant Issue

This pull request resolves #56 

### Description of Changes

This creates the `matters/:id` route and corresponding page. Everywhere a matter is referenced or discussed (a Person's legislation history, a meeting votes table, an event page) there should now be a link to the associated matter. 

### Link to Forked Storybook Site

[The site](https://BrianL3.github.io/cdp-frontend/)
