### PR TITLE
fix/populate-event-in-event_minutes_item

### DIFF
--- a/src/networking/MatterStatusService.ts
+++ b/src/networking/MatterStatusService.ts
@@ -18,9 +18,14 @@ export default class MatterStatusService extends ModelService {
   }
 
   async getMatterStatusesByMatterId(matterId: string): Promise<MatterStatus[]> {
+    const populateEvent = new Populate(
+      COLLECTION_NAME.EventMinutesItem,
+      REF_PROPERTY_NAME.EventMinutesItemEventRef
+    );
     const populateEventMinutesItems = new Populate(
       COLLECTION_NAME.MatterStatus,
-      REF_PROPERTY_NAME.MatterStatusEventMinutesItemRef
+      REF_PROPERTY_NAME.MatterStatusEventMinutesItemRef,
+      new PopulationOptions([populateEvent])
     );
 
     const networkQueryResponse = this.networkService.getDocuments(


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  ⚠️⚠️ Please do the following before submitting: ⚠️⚠️

  - Read the CONTRIBUTING.md guide and make sure you've followed all the steps given.
  - Ensure that the code is up-to-date with the `main` branch.
  - Provide or update documentation for any feature added by your pull request.
  - Provide relevant tests for your feature or bug fix.

  ❗️ Also: ❗️

  Please name your pull request {development-type}/{short-description}.
  For example: feature/read-tiff-files
-->

### Link to Relevant Issue

This pull request resolves #

### Description of Changes

_Include a description of the proposed changes._
In the matter page's history section, each history node expects an `Event` so that it can display the event's date and link to it. This just populates the `Event` for each `EventMinutesItem` of each `MatterStatus`.

### Link to Forked Storybook Site

_If component changes (especially visual changes) are contained in this PR, we ask that you provide a link to a publicly viewable version of the Storybook docs site, so PR reviewers can see your changes without having to install and view your code locally._

_Please see `CONTRIBUTING.md` for directions on how this can be done._
Before: 
![image](https://user-images.githubusercontent.com/37560480/173264747-f348b210-6c9e-49dc-a739-fa87e5a12aeb.png)

After: screenshot of linked event
![image](https://user-images.githubusercontent.com/37560480/173264413-6c5a290f-0539-4d29-80a2-25bc1697d8b2.png)

