### PR TITLE
Fix/make council votes default expanded

### DIFF
--- a/src/components/Tables/MeetingVotesTable/MeetingVotesTable.tsx
+++ b/src/components/Tables/MeetingVotesTable/MeetingVotesTable.tsx
@@ -42,7 +42,6 @@ const MeetingVotesTable = ({ votesPage }: MeetingVotesTableProps) => {
 
   return (
     <>
-      {<p>{strings.meeting_votes_caption}</p>}
       <ReactiveTable
         data={votesPage}
         columnDistribution={COLUMN_DISTRIBUTION}

--- a/src/components/Tables/MeetingVotesTableRow/MeetingVotesTableRow.tsx
+++ b/src/components/Tables/MeetingVotesTableRow/MeetingVotesTableRow.tsx
@@ -102,7 +102,6 @@ const MeetingVotesTableRow = ({
   columnNames,
   columnDistribution,
 }: MeetingVotesTableRowProps) => {
-  const [expanded, setExpanded] = useState(false);
   const isMobile = useMediaQuery({ query: `(max-width: ${screenWidths.tablet})` });
 
   return (

--- a/src/components/Tables/MeetingVotesTableRow/MeetingVotesTableRow.tsx
+++ b/src/components/Tables/MeetingVotesTableRow/MeetingVotesTableRow.tsx
@@ -28,7 +28,8 @@ type MeetingVotesTableRowProps = {
   columnDistribution: string[];
 };
 
-function VoteCell(isExpanded: boolean, votes: IndividualMeetingVote[], isMobile: boolean) {
+function VoteCell(votes: IndividualMeetingVote[], isMobile: boolean) {
+  const [expanded, setExpanded] = useState(false);
   let votesFor = 0;
   let votesAgainst = 0;
   let nonVotes = 0;
@@ -110,9 +111,6 @@ const MeetingVotesTableRow = ({
       index={index}
       columnNames={columnNames}
       columnDistribution={columnDistribution}
-      onClick={() => {
-        setExpanded(!expanded);
-      }}
     >
       <div>
         <Link to={legislationLink}>
@@ -123,7 +121,7 @@ const MeetingVotesTableRow = ({
         {!isMobile && <p>{legislationDescription}</p>}
       </div>
       <DecisionResult result={councilDecision} />
-      {VoteCell(expanded, votes, isMobile)}
+      {VoteCell(votes, isMobile)}
     </ReactiveTableRow>
   );
 };

--- a/src/components/Tables/MeetingVotesTableRow/MeetingVotesTableRow.tsx
+++ b/src/components/Tables/MeetingVotesTableRow/MeetingVotesTableRow.tsx
@@ -29,6 +29,41 @@ type MeetingVotesTableRowProps = {
 };
 
 function VoteCell(isExpanded: boolean, votes: IndividualMeetingVote[], isMobile: boolean) {
+  let votesFor = 0;
+  let votesAgainst = 0;
+  let nonVotes = 0;
+  votes.forEach((vote) => {
+    if (
+      [VOTE_DECISION.ABSENT_APPROVE, VOTE_DECISION.ABSTAIN_APPROVE, VOTE_DECISION.APPROVE].includes(
+        vote.decision
+      )
+    )
+      votesFor++;
+    if (
+      [VOTE_DECISION.ABSENT_REJECT, VOTE_DECISION.ABSTAIN_REJECT, VOTE_DECISION.REJECT].includes(
+        vote.decision
+      )
+    )
+      votesAgainst++;
+    if ([VOTE_DECISION.ABSENT_NON_VOTING, VOTE_DECISION.ABSTAIN_NON_VOTING].includes(vote.decision))
+      nonVotes++;
+  });
+  const votesForLabel = strings.number_approved.replace("{number}", `${votesFor}`);
+  const votesAgainstLabel = strings.number_rejected.replace("{number}", `${votesAgainst}`);
+  const votesAbstainedLabel = strings.number_non_voting.replace("{number}", `${nonVotes}`);
+  if (isMobile) {
+    return (
+      <div style={{ display: "flex", flexDirection: "column" }}>
+        <p>{votesForLabel}</p>
+        <p>{votesAgainstLabel}</p>
+        <p>{votesAbstainedLabel}</p>
+      </div>
+    );
+  } else {
+    return (
+      <p>{`${votesForLabel} ${TAG_CONNECTOR} ${votesAgainstLabel} ${TAG_CONNECTOR} ${votesAbstainedLabel}`}</p>
+    );
+  }
   if (isExpanded) {
     return (
       <React.Fragment>
@@ -53,46 +88,6 @@ function VoteCell(isExpanded: boolean, votes: IndividualMeetingVote[], isMobile:
         })}
       </React.Fragment>
     );
-  } else {
-    let votesFor = 0;
-    let votesAgainst = 0;
-    let nonVotes = 0;
-    votes.forEach((vote) => {
-      if (
-        [
-          VOTE_DECISION.ABSENT_APPROVE,
-          VOTE_DECISION.ABSTAIN_APPROVE,
-          VOTE_DECISION.APPROVE,
-        ].includes(vote.decision)
-      )
-        votesFor++;
-      if (
-        [VOTE_DECISION.ABSENT_REJECT, VOTE_DECISION.ABSTAIN_REJECT, VOTE_DECISION.REJECT].includes(
-          vote.decision
-        )
-      )
-        votesAgainst++;
-      if (
-        [VOTE_DECISION.ABSENT_NON_VOTING, VOTE_DECISION.ABSTAIN_NON_VOTING].includes(vote.decision)
-      )
-        nonVotes++;
-    });
-    const votesForLabel = strings.number_approved.replace("{number}", `${votesFor}`);
-    const votesAgainstLabel = strings.number_rejected.replace("{number}", `${votesAgainst}`);
-    const votesAbstainedLabel = strings.number_non_voting.replace("{number}", `${nonVotes}`);
-    if (isMobile) {
-      return (
-        <div style={{ display: "flex", flexDirection: "column" }}>
-          <p>{votesForLabel}</p>
-          <p>{votesAgainstLabel}</p>
-          <p>{votesAbstainedLabel}</p>
-        </div>
-      );
-    } else {
-      return (
-        <p>{`${votesForLabel} ${TAG_CONNECTOR} ${votesAgainstLabel} ${TAG_CONNECTOR} ${votesAbstainedLabel}`}</p>
-      );
-    }
   }
 }
 

--- a/src/components/Tables/MeetingVotesTableRow/MeetingVotesTableRow.tsx
+++ b/src/components/Tables/MeetingVotesTableRow/MeetingVotesTableRow.tsx
@@ -88,6 +88,9 @@ function VoteCell(votes: IndividualMeetingVote[], isMobile: boolean) {
       {votes.length > 5 && (
         <button
           className="mzp-c-button mzp-t-product mzp-t-secondary mzp-t-sm"
+          style={{
+            marginTop: 10,
+          }}
           onClick={() => {
             setExpanded(!expanded);
           }}

--- a/src/components/Tables/MeetingVotesTableRow/MeetingVotesTableRow.tsx
+++ b/src/components/Tables/MeetingVotesTableRow/MeetingVotesTableRow.tsx
@@ -52,44 +52,50 @@ function VoteCell(votes: IndividualMeetingVote[], isMobile: boolean) {
   const votesForLabel = strings.number_approved.replace("{number}", `${votesFor}`);
   const votesAgainstLabel = strings.number_rejected.replace("{number}", `${votesAgainst}`);
   const votesAbstainedLabel = strings.number_non_voting.replace("{number}", `${nonVotes}`);
-  if (isMobile) {
-    return (
-      <div style={{ display: "flex", flexDirection: "column" }}>
-        <p>{votesForLabel}</p>
-        <p>{votesAgainstLabel}</p>
-        <p>{votesAbstainedLabel}</p>
-      </div>
-    );
-  } else {
-    return (
-      <p>{`${votesForLabel} ${TAG_CONNECTOR} ${votesAgainstLabel} ${TAG_CONNECTOR} ${votesAbstainedLabel}`}</p>
-    );
-  }
-  if (isExpanded) {
-    return (
-      <React.Fragment>
-        {votes.map((vote, index) => {
-          const personLink = `/people/${vote.personId}`;
-          return (
-            <div
-              key={`individual-vote-${index}-${vote.id}`}
-              style={{
-                display: "flex",
-                flexDirection: "row",
-                justifyContent: "center",
-                alignItems: "center",
-              }}
-            >
-              <Link style={{ flex: 1 }} to={personLink}>
-                {vote.name}
-              </Link>
-              <DecisionResult result={vote.decision} />
-            </div>
-          );
-        })}
-      </React.Fragment>
-    );
-  }
+  return (
+    <React.Fragment>
+      {isMobile ? (
+        <div style={{ display: "flex", flexDirection: "column" }}>
+          <p>{votesForLabel}</p>
+          <p>{votesAgainstLabel}</p>
+          <p>{votesAbstainedLabel}</p>
+        </div>
+      ) : (
+        <p>{`${votesForLabel} ${TAG_CONNECTOR} ${votesAgainstLabel} ${TAG_CONNECTOR} ${votesAbstainedLabel}`}</p>
+      )}
+      {votes.map((vote, index) => {
+        if (!expanded && index > 4) {
+          return;
+        }
+        const personLink = `/people/${vote.personId}`;
+        return (
+          <div
+            key={`individual-vote-${index}-${vote.id}`}
+            style={{
+              display: "flex",
+              flexDirection: "row",
+              justifyContent: "center",
+              alignItems: "center",
+            }}
+          >
+            <Link style={{ flex: 1 }} to={personLink}>
+              {vote.name}
+            </Link>
+            <DecisionResult result={vote.decision} />
+          </div>
+        );
+      })}
+      {votes.length > 5 && (
+        <button
+          onClick={() => {
+            setExpanded(!expanded);
+          }}
+        >
+          {expanded ? "Show Less" : "Show All Votes for Matter "}
+        </button>
+      )}
+    </React.Fragment>
+  );
 }
 
 const MeetingVotesTableRow = ({

--- a/src/components/Tables/MeetingVotesTableRow/MeetingVotesTableRow.tsx
+++ b/src/components/Tables/MeetingVotesTableRow/MeetingVotesTableRow.tsx
@@ -87,6 +87,7 @@ function VoteCell(votes: IndividualMeetingVote[], isMobile: boolean) {
       })}
       {votes.length > 5 && (
         <button
+          className="mzp-c-button mzp-t-product mzp-t-secondary mzp-t-sm"
           onClick={() => {
             setExpanded(!expanded);
           }}

--- a/src/components/Tables/MeetingVotesTableRow/MeetingVotesTableRow.tsx
+++ b/src/components/Tables/MeetingVotesTableRow/MeetingVotesTableRow.tsx
@@ -61,42 +61,44 @@ function VoteCell(votes: IndividualMeetingVote[], isMobile: boolean) {
           <p>{votesAbstainedLabel}</p>
         </div>
       ) : (
-        <p>{`${votesForLabel} ${TAG_CONNECTOR} ${votesAgainstLabel} ${TAG_CONNECTOR} ${votesAbstainedLabel}`}</p>
-      )}
-      {votes.map((vote, index) => {
-        if (!expanded && index > 4) {
-          return;
-        }
-        const personLink = `/people/${vote.personId}`;
-        return (
-          <div
-            key={`individual-vote-${index}-${vote.id}`}
-            style={{
-              display: "flex",
-              flexDirection: "row",
-              justifyContent: "center",
-              alignItems: "center",
-            }}
-          >
-            <Link style={{ flex: 1 }} to={personLink}>
-              {vote.name}
-            </Link>
-            <DecisionResult result={vote.decision} />
-          </div>
-        );
-      })}
-      {votes.length > 5 && (
-        <button
-          className="mzp-c-button mzp-t-product mzp-t-secondary mzp-t-sm"
-          style={{
-            marginTop: 10,
-          }}
-          onClick={() => {
-            setExpanded(!expanded);
-          }}
-        >
-          {expanded ? "Show Less" : "Show All Votes for Matter "}
-        </button>
+        <>
+          <p>{`${votesForLabel} ${TAG_CONNECTOR} ${votesAgainstLabel} ${TAG_CONNECTOR} ${votesAbstainedLabel}`}</p>
+          {votes.map((vote, index) => {
+            if (!expanded && index > 4) {
+              return;
+            }
+            const personLink = `/people/${vote.personId}`;
+            return (
+              <div
+                key={`individual-vote-${index}-${vote.id}`}
+                style={{
+                  display: "flex",
+                  flexDirection: "row",
+                  justifyContent: "center",
+                  alignItems: "center",
+                }}
+              >
+                <Link style={{ flex: 1 }} to={personLink}>
+                  {vote.name}
+                </Link>
+                <DecisionResult result={vote.decision} />
+              </div>
+            );
+          })}
+          {votes.length > 5 && (
+            <button
+              className="mzp-c-button mzp-t-product mzp-t-secondary mzp-t-sm"
+              style={{
+                marginTop: 10,
+              }}
+              onClick={() => {
+                setExpanded(!expanded);
+              }}
+            >
+              {expanded ? "Show Less" : "Show All Votes for Matter "}
+            </button>
+          )}
+        </>
       )}
     </React.Fragment>
   );


### PR DESCRIPTION
### Link to Relevant Issue
https://github.com/CouncilDataProject/cdp-frontend/issues/163

### Description of Changes
Reworks MeetingVoteTableRow to have council votes always be expanded if 5 or less council members are present.
If more than 5 council members are in the meeting, only show the first 5, then render a clickable button to show more. 

### Link to Forked Storybook Site
https://jonlin14.github.io/cdp-frontend/#/events/756436a9130b -- Five council members, no button as expected
https://jonlin14.github.io/cdp-frontend/#/events/de58242d129b -- Seven council members, shows an expand button and hides any council members past 5 as expected. 

