### PR TITLE
bugfix/use-correct-collection-in-votes-service-networking-layer

### DIFF
--- a/src/networking/PopulationOptions.ts
+++ b/src/networking/PopulationOptions.ts
@@ -92,7 +92,7 @@ export function getCollectionForReference(reference: string): COLLECTION_NAME | 
     case REF_PROPERTY_NAME.TranscriptSessionRef:
       return COLLECTION_NAME.Session;
     case REF_PROPERTY_NAME.VoteEventMinutesItemRef:
-      return COLLECTION_NAME.MinutesItem;
+      return COLLECTION_NAME.EventMinutesItem;
     case REF_PROPERTY_NAME.VoteEventRef:
       return COLLECTION_NAME.Event;
     case REF_PROPERTY_NAME.VoteMatterRef:


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  ⚠️⚠️ Please do the following before submitting: ⚠️⚠️

  - Read the CONTRIBUTING.md guide and make sure you've followed all the steps given.
  - Ensure that the code is up-to-date with the `main` branch.
  - Provide or update documentation for any feature added by your pull request.
  - Provide relevant tests for your feature or bug fix.

  ❗️ Also: ❗️

  Please name your pull request {development-type}/{short-description}.
  For example: feature/read-tiff-files
-->

### Link to Relevant Issue

This pull request resolves #252 

### Description of Changes

Fixing the collection name used in the `VoteEventMinutesItemRef` to refer to the `EventMinutesItem` model. This should allow the firebase query to properly go through, since it'll be consistent with the [`Vote` model](https://github.com/CouncilDataProject/cdp-backend/blob/311ee4b7640bb94b42207e9a20a887111ec584c0/cdp_backend/database/models.py#L713) 

### Link to Forked Storybook Site
This is a networking layer change

