### PR TITLE
bug-fix/case-search-issues

### DIFF
--- a/src/components/Details/TranscriptItem/TranscriptItem.tsx
+++ b/src/components/Details/TranscriptItem/TranscriptItem.tsx
@@ -154,7 +154,7 @@ const TranscriptItem: FC<TranscriptItemProps> = ({
       // no query or valid tokens to highlight
       return [];
     }
-    const stemmedQuery = tokenizedQuery.map((token) => stem(token));
+    const stemmedQuery = tokenizedQuery.map((token) => stem(token.toLowerCase()));
     // highlight the token or the stem
     const regExps = tokenizedQuery.map(
       (token, i) => new RegExp(`\\b(${token}|${stemmedQuery[i]})`, "g")

--- a/src/components/Details/TranscriptSearch/TranscriptSearch.tsx
+++ b/src/components/Details/TranscriptSearch/TranscriptSearch.tsx
@@ -87,7 +87,7 @@ const TranscriptSearch: FC<TranscriptSearchProps> = ({
       return sentences.data.map(({ text }) => {
         const cleanedText = cleanText(text);
         const tokens = removeStopwords(cleanedText.split(" "));
-        const stems = tokens.map((token) => stem(token).toLowerCase());
+        const stems = tokens.map((token) => stem(token.toLowerCase()));
         return new Set(stems);
       });
     }
@@ -106,7 +106,7 @@ const TranscriptSearch: FC<TranscriptSearchProps> = ({
         // empty query or no valid tokens to search
         return [];
       }
-      const stemmedQuery = tokenizedQuery.map((token) => stem(token).toLowerCase());
+      const stemmedQuery = tokenizedQuery.map((token) => stem(token.toLowerCase()));
       return sentences.data.filter((_, i) => stemmedQuery.some((q) => stemmedSentences[i].has(q)));
     }
     return [];

--- a/src/networking/EventSearchService.ts
+++ b/src/networking/EventSearchService.ts
@@ -96,10 +96,9 @@ export default class EventSearchService {
         stemmedGrams.push(
           gramSet
             .map((gram) => {
-              return stem(gram);
+              return stem(gram.toLowerCase());
             })
             .join(" ")
-            .toLowerCase()
         );
       });
     });


### PR DESCRIPTION
### Link to Relevant Issue

https://github.com/CouncilDataProject/cdp-frontend/issues/243
(I left additional notes here)

### Description of Changes

Changing transcriptSearch to lowerCase first before stemming.
Adding lowerCasing to TranscriptItem component so the words that the search results returned will now also be highlighted (for example Abortion will now highlight abort).

### Link to Forked Storybook Site

https://councildataproject.org/seattle/#/events/e711bed20cda
Abortion will return 0 results, abortion will return 1.

https://jonlin14.github.io/cdp-frontend/#/events/e711bed20cda
Abortion will return the expected 1 result, abortion will return 1.
