### PR TITLE
Bugfix/change transcript selection to most recent

### DIFF
--- a/src/index-react.tsx
+++ b/src/index-react.tsx
@@ -8,7 +8,7 @@ ReactDOM.render(
       appConfig={{
         firebaseConfig: {
           options: {
-            projectId: "cdp-seattle-staging-dbengvtn",
+            projectId: "cdp-seattle-21723dcf",
           },
           settings: {},
         },

--- a/src/networking/TranscriptService.ts
+++ b/src/networking/TranscriptService.ts
@@ -27,7 +27,7 @@ export default class TranscriptService extends ModelService {
           WHERE_OPERATOR.eq,
           doc(NetworkService.getDb(), COLLECTION_NAME.Session, sessionId)
         ),
-        orderBy("confidence", ORDER_DIRECTION.desc),
+        orderBy("created", ORDER_DIRECTION.desc),
         limit(1),
       ],
       new PopulationOptions([

--- a/src/pages/EventPage/EventPage.tsx
+++ b/src/pages/EventPage/EventPage.tsx
@@ -113,6 +113,7 @@ const EventPage: FC = () => {
       // Create transcript items from the transcripts
       const transcriptJsons = await Promise.all(
         transcripts.map((transcript) => {
+          console.log("Transcript JSON Data", transcript[0]);
           return transcriptJsonService.download(transcript[0].file?.uri as string);
         })
       );


### PR DESCRIPTION
### Link to Relevant Issue

https://github.com/CouncilDataProject/cdp-frontend/issues/256

### Description of Changes

Change ordering of transcripts to created timestamp in descending order. 

### Link to Forked Storybook Site
I changed my branch to point at production's config and I can confirm that the transcripts have changed. Does it look to be the correct one?

https://jonlin14.github.io/cdp-frontend/#/events/efb9560456b1
https://councildataproject.org/seattle/#/events/efb9560456b1

Also, I published the page with the config change to point to production but I didn't commit that change. Let me know if I should include it or not.
