### PR TITLE
Bug/correct-disclaimer-text

### DIFF
--- a/src/assets/LocalizedStrings.tsx
+++ b/src/assets/LocalizedStrings.tsx
@@ -105,7 +105,6 @@ export interface MasterStringsList extends LocalizedStringsMethods {
   disclaimer_start: string;
   disclaimer_end: string;
   disclaimer_include_errors: string;
-  disclaimer_footer_start: string;
   disclaimer_footer_end: string;
   copy_button: string;
   donate: string;

--- a/src/assets/LocalizedStrings.tsx
+++ b/src/assets/LocalizedStrings.tsx
@@ -104,6 +104,7 @@ export interface MasterStringsList extends LocalizedStringsMethods {
   go_to_matter_details: string;
   disclaimer_start: string;
   disclaimer_end: string;
+  disclaimer_include_errors: string;
   disclaimer_footer_start: string;
   disclaimer_footer_end: string;
   copy_button: string;

--- a/src/assets/strings/de.ts
+++ b/src/assets/strings/de.ts
@@ -91,9 +91,10 @@ const de = {
   history: "Geschichte",
   minutes: "Protokoll",
   go_to_matter_details: "Gehen Sie zu den vollständigen Rechtsvorschriften",
-  disclaimer_start:
-    "Um Transkripte von Veranstaltungen kostengünstig bereitzustellen, verwendet Council Data Project",
-  disclaimer_end: "für die Transkription. Ereignisprotokolle können Fehler enthalten.",
+  disclaimer_start: "Council Data Project nutzt",
+  disclaimer_end:
+    "Modell zur Generierung von Ereignistranskripten. Die erstellten Transkripte können",
+  disclaimer_include_errors: "Fehler enthalten.",
   disclaimer_footer_start: "In vielen Fällen verwendet Council Data Project ein fein abgestimmtes",
   disclaimer_footer_end:
     "Modell zur Generierung von Ereignisprotokollen. Wir verstehen, dass Transkripte Fehler enthalten können. Wenn Sie ein Experte für maschinelles Lernen sind und dabei helfen möchten, unser System zum Generieren von Transkripten zu verbessern, kontaktieren Sie uns bitte auf GitHub.",

--- a/src/assets/strings/de.ts
+++ b/src/assets/strings/de.ts
@@ -97,7 +97,7 @@ const de = {
   disclaimer_include_errors: "Fehler enthalten",
   disclaimer_footer_start: "In vielen Fällen verwendet Council Data Project ein fein abgestimmtes",
   disclaimer_footer_end:
-    "Modell zur Generierung von Ereignisprotokollen. Wir verstehen, dass Transkripte Fehler enthalten können. Wenn Sie ein Experte für maschinelles Lernen sind und dabei helfen möchten, unser System zum Generieren von Transkripten zu verbessern, kontaktieren Sie uns bitte auf GitHub.",
+    "Wenn Sie ein Experte für maschinelles Lernen sind und dabei helfen möchten, unsere Systeme zur Generierung von Transkripten (oder etwas anderem!) zu verbessern, wenden Sie sich bitte über GitHub an uns.",
   copy_button: "Text kopieren",
   donate: "Spenden",
 };

--- a/src/assets/strings/de.ts
+++ b/src/assets/strings/de.ts
@@ -94,7 +94,7 @@ const de = {
   disclaimer_start: "Council Data Project nutzt",
   disclaimer_end:
     "Modell zur Generierung von Ereignistranskripten. Die erstellten Transkripte können",
-  disclaimer_include_errors: "Fehler enthalten.",
+  disclaimer_include_errors: "Fehler enthalten",
   disclaimer_footer_start: "In vielen Fällen verwendet Council Data Project ein fein abgestimmtes",
   disclaimer_footer_end:
     "Modell zur Generierung von Ereignisprotokollen. Wir verstehen, dass Transkripte Fehler enthalten können. Wenn Sie ein Experte für maschinelles Lernen sind und dabei helfen möchten, unser System zum Generieren von Transkripten zu verbessern, kontaktieren Sie uns bitte auf GitHub.",

--- a/src/assets/strings/de.ts
+++ b/src/assets/strings/de.ts
@@ -95,7 +95,6 @@ const de = {
   disclaimer_end:
     "Modell zur Generierung von Ereignistranskripten. Die erstellten Transkripte können",
   disclaimer_include_errors: "Fehler enthalten",
-  disclaimer_footer_start: "In vielen Fällen verwendet Council Data Project ein fein abgestimmtes",
   disclaimer_footer_end:
     "Wenn Sie ein Experte für maschinelles Lernen sind und dabei helfen möchten, unsere Systeme zur Generierung von Transkripten (oder etwas anderem!) zu verbessern, wenden Sie sich bitte über GitHub an uns.",
   copy_button: "Text kopieren",

--- a/src/assets/strings/en.ts
+++ b/src/assets/strings/en.ts
@@ -90,8 +90,8 @@ const en = {
   history: "History",
   minutes: "Minutes",
   go_to_matter_details: "Go to Full Legislation Details",
-  disclaimer_start: "To provide event transcripts at low-cost, Council Data Project uses",
-  disclaimer_end: "for transcription. Event transcripts may include errors.",
+  disclaimer_start: "Council Data Project utilizes",
+  disclaimer_end: "model for generation of event transcripts. The produced transcripts may",
   disclaimer_footer_start: "In many cases, Council Data Project utilizes a fine-tuned",
   disclaimer_footer_end:
     "model for generation of event transcripts. We understand that transcripts may include errors. If you are a machine learning expert and wish to help improve our system for generating transcripts, please reach out to us on GitHub.",

--- a/src/assets/strings/en.ts
+++ b/src/assets/strings/en.ts
@@ -92,6 +92,7 @@ const en = {
   go_to_matter_details: "Go to Full Legislation Details",
   disclaimer_start: "Council Data Project utilizes",
   disclaimer_end: "model for generation of event transcripts. The produced transcripts may",
+  disclaimer_include_errors: "include errors",
   disclaimer_footer_start: "In many cases, Council Data Project utilizes a fine-tuned",
   disclaimer_footer_end:
     "model for generation of event transcripts. We understand that transcripts may include errors. If you are a machine learning expert and wish to help improve our system for generating transcripts, please reach out to us on GitHub.",

--- a/src/assets/strings/en.ts
+++ b/src/assets/strings/en.ts
@@ -95,7 +95,7 @@ const en = {
   disclaimer_include_errors: "include errors",
   disclaimer_footer_start: "In many cases, Council Data Project utilizes a fine-tuned",
   disclaimer_footer_end:
-    "model for generation of event transcripts. We understand that transcripts may include errors. If you are a machine learning expert and wish to help improve our system for generating transcripts, please reach out to us on GitHub.",
+    "If you are a machine learning expert and wish to help improve our systems for generating transcripts (or something else!), please reach out to us on GitHub.",
   copy_button: "Copy text",
   donate: "Donate",
 };

--- a/src/assets/strings/en.ts
+++ b/src/assets/strings/en.ts
@@ -93,7 +93,6 @@ const en = {
   disclaimer_start: "Council Data Project utilizes",
   disclaimer_end: "model for generation of event transcripts. The produced transcripts may",
   disclaimer_include_errors: "include errors",
-  disclaimer_footer_start: "In many cases, Council Data Project utilizes a fine-tuned",
   disclaimer_footer_end:
     "If you are a machine learning expert and wish to help improve our systems for generating transcripts (or something else!), please reach out to us on GitHub.",
   copy_button: "Copy text",

--- a/src/assets/strings/en.ts
+++ b/src/assets/strings/en.ts
@@ -92,7 +92,7 @@ const en = {
   go_to_matter_details: "Go to Full Legislation Details",
   disclaimer_start: "Council Data Project utilizes",
   disclaimer_end: "model for generation of event transcripts. The produced transcripts may",
-  disclaimer_include_errors: "include errors.",
+  disclaimer_include_errors: "include errors",
   disclaimer_footer_start: "In many cases, Council Data Project utilizes a fine-tuned",
   disclaimer_footer_end:
     "model for generation of event transcripts. We understand that transcripts may include errors. If you are a machine learning expert and wish to help improve our system for generating transcripts, please reach out to us on GitHub.",

--- a/src/assets/strings/en.ts
+++ b/src/assets/strings/en.ts
@@ -92,7 +92,7 @@ const en = {
   go_to_matter_details: "Go to Full Legislation Details",
   disclaimer_start: "Council Data Project utilizes",
   disclaimer_end: "model for generation of event transcripts. The produced transcripts may",
-  disclaimer_include_errors: "include errors",
+  disclaimer_include_errors: "include errors.",
   disclaimer_footer_start: "In many cases, Council Data Project utilizes a fine-tuned",
   disclaimer_footer_end:
     "model for generation of event transcripts. We understand that transcripts may include errors. If you are a machine learning expert and wish to help improve our system for generating transcripts, please reach out to us on GitHub.",

--- a/src/assets/strings/es.ts
+++ b/src/assets/strings/es.ts
@@ -90,9 +90,10 @@ const es = {
   history: "Historia",
   minutes: "Protocolo",
   go_to_matter_details: "Ir a los detalles completos de la legislación",
-  disclaimer_start:
-    "Para proporcionar transcripciones de eventos a bajo costo, Council Data Project utiliza",
-  disclaimer_end: "para la transcripción. Las transcripciones de eventos pueden incluir errores.",
+  disclaimer_start: "Council Data Project utiliza",
+  disclaimer_end:
+    "modelo para la generación de transcripciones de eventos. Las transcripciones producidas pueden",
+  disclaimer_include_errors: "incluir errores.",
   disclaimer_footer_start: "En muchos casos, Council Data Project utiliza un",
   disclaimer_footer_end:
     "modelo perfeccionado para la generación de transcripciones de eventos. Entendemos que las transcripciones pueden incluir errores. Si es un experto en aprendizaje automático y desea ayudar a mejorar nuestro sistema para generar transcripciones, comuníquese con nosotros en GitHub.",

--- a/src/assets/strings/es.ts
+++ b/src/assets/strings/es.ts
@@ -96,7 +96,7 @@ const es = {
   disclaimer_include_errors: "incluir errores",
   disclaimer_footer_start: "En muchos casos, Council Data Project utiliza un",
   disclaimer_footer_end:
-    "modelo perfeccionado para la generación de transcripciones de eventos. Entendemos que las transcripciones pueden incluir errores. Si es un experto en aprendizaje automático y desea ayudar a mejorar nuestro sistema para generar transcripciones, comuníquese con nosotros en GitHub.",
+    "Si es un experto en aprendizaje automático y desea ayudar a mejorar nuestros sistemas para generar transcripciones (¡o algo más!), comuníquese con nosotros en GitHub.",
   copy_button: "Copiar texto",
   donate: "Donar",
 };

--- a/src/assets/strings/es.ts
+++ b/src/assets/strings/es.ts
@@ -94,7 +94,6 @@ const es = {
   disclaimer_end:
     "modelo para la generación de transcripciones de eventos. Las transcripciones producidas pueden",
   disclaimer_include_errors: "incluir errores",
-  disclaimer_footer_start: "En muchos casos, Council Data Project utiliza un",
   disclaimer_footer_end:
     "Si es un experto en aprendizaje automático y desea ayudar a mejorar nuestros sistemas para generar transcripciones (¡o algo más!), comuníquese con nosotros en GitHub.",
   copy_button: "Copiar texto",

--- a/src/assets/strings/es.ts
+++ b/src/assets/strings/es.ts
@@ -93,7 +93,7 @@ const es = {
   disclaimer_start: "Council Data Project utiliza",
   disclaimer_end:
     "modelo para la generación de transcripciones de eventos. Las transcripciones producidas pueden",
-  disclaimer_include_errors: "incluir errores.",
+  disclaimer_include_errors: "incluir errores",
   disclaimer_footer_start: "En muchos casos, Council Data Project utiliza un",
   disclaimer_footer_end:
     "modelo perfeccionado para la generación de transcripciones de eventos. Entendemos que las transcripciones pueden incluir errores. Si es un experto en aprendizaje automático y desea ayudar a mejorar nuestro sistema para generar transcripciones, comuníquese con nosotros en GitHub.",

--- a/src/components/Layout/Footer/Footer.tsx
+++ b/src/components/Layout/Footer/Footer.tsx
@@ -69,15 +69,23 @@ const Footer: FC<FooterProps> = ({ footerLinksSections }: FooterProps) => {
 
         <nav className="mzp-c-footer-secondary">
           <p>
-            {strings.disclaimer_footer_start}{" "}
+            {strings.disclaimer_start}{" "}
             <a
               rel="noopener noreferrer license external"
               target="_blank"
-              href="https://cloud.google.com/speech-to-text"
+              href="https://openai.com/research/whisper"
             >
-              Google Speech-to-Text
+              OpenAi's Whisper Speech-to-Text model
             </a>{" "}
-            {strings.disclaimer_footer_end}
+            {strings.disclaimer_end}{" "}
+            <a
+              rel="noopener noreferrer license external"
+              href="https://cdn.openai.com/papers/whisper.pdf"
+              target="_blank"
+            >
+              {strings.disclaimer_include_errors}
+            </a>
+            . {strings.disclaimer_footer_end}
           </p>
 
           <div className="mzp-c-footer-legal mzp-c-footer-license">

--- a/src/components/Layout/Footer/Footer.tsx
+++ b/src/components/Layout/Footer/Footer.tsx
@@ -75,7 +75,7 @@ const Footer: FC<FooterProps> = ({ footerLinksSections }: FooterProps) => {
               target="_blank"
               href="https://openai.com/research/whisper"
             >
-              OpenAi's Whisper Speech-to-Text model
+              OpenAi's Whisper Speech-to-Text Model
             </a>{" "}
             {strings.disclaimer_end}{" "}
             <a

--- a/src/components/Layout/Footer/Footer.tsx
+++ b/src/components/Layout/Footer/Footer.tsx
@@ -75,7 +75,7 @@ const Footer: FC<FooterProps> = ({ footerLinksSections }: FooterProps) => {
               target="_blank"
               href="https://openai.com/research/whisper"
             >
-              OpenAi's Whisper Speech-to-Text Model
+              OpenAI&apos;s Whisper Speech-to-Text Model
             </a>{" "}
             {strings.disclaimer_end}{" "}
             <a

--- a/src/containers/SearchEventsContainer/SearchEventsContainer.tsx
+++ b/src/containers/SearchEventsContainer/SearchEventsContainer.tsx
@@ -245,7 +245,7 @@ const SearchEventsContainer: FC<SearchEventsContainerData> = ({
           href="https://cdn.openai.com/papers/whisper.pdf"
           target="_blank"
         >
-          include errors.
+          {strings.disclaimer_include_errors}
         </a>
       </p>
       {fetchEventsResult}

--- a/src/containers/SearchEventsContainer/SearchEventsContainer.tsx
+++ b/src/containers/SearchEventsContainer/SearchEventsContainer.tsx
@@ -234,12 +234,19 @@ const SearchEventsContainer: FC<SearchEventsContainerData> = ({
         {strings.disclaimer_start}{" "}
         <a
           rel="noopener noreferrer license external"
-          href="https://cloud.google.com/speech-to-text"
+          href="https://openai.com/research/whisper"
           target="_blank"
         >
-          Google Speech-to-Text
+          OpenAI's Whisper Speech-to-Text Model
         </a>{" "}
-        {strings.disclaimer_end}
+        {strings.disclaimer_end}{" "}
+        <a
+          rel="noopener noreferrer license external"
+          href="https://cdn.openai.com/papers/whisper.pdf"
+          target="_blank"
+        >
+          include errors.
+        </a>
       </p>
       {fetchEventsResult}
       <ShowMoreCards isVisible={showMoreEvents}>

--- a/src/containers/SearchEventsContainer/SearchEventsContainer.tsx
+++ b/src/containers/SearchEventsContainer/SearchEventsContainer.tsx
@@ -247,6 +247,7 @@ const SearchEventsContainer: FC<SearchEventsContainerData> = ({
         >
           {strings.disclaimer_include_errors}
         </a>
+        .
       </p>
       {fetchEventsResult}
       <ShowMoreCards isVisible={showMoreEvents}>

--- a/src/containers/SearchEventsContainer/SearchEventsContainer.tsx
+++ b/src/containers/SearchEventsContainer/SearchEventsContainer.tsx
@@ -237,7 +237,7 @@ const SearchEventsContainer: FC<SearchEventsContainerData> = ({
           href="https://openai.com/research/whisper"
           target="_blank"
         >
-          OpenAI's Whisper Speech-to-Text Model
+          OpenAI&apos;s Whisper Speech-to-Text Model
         </a>{" "}
         {strings.disclaimer_end}{" "}
         <a


### PR DESCRIPTION
### Link to Relevant Issue

This pull request resolves #264 

### Description of Changes

Update disclaimer text and their localization. Removed disclaimer_footer_start string as it's now a duplicate since both disclaimers start with the same string.

### Link to Forked Storybook Site

https://jonlin14.github.io/cdp-frontend/#/events/search?q=abc
Events banner and footer both updated to reflect text in https://github.com/CouncilDataProject/cdp-frontend/issues/264#issuecomment-1610581715
